### PR TITLE
fix(smoke): use exact matching to prevent Certificates/Trusted Certificates ambiguity

### DIFF
--- a/czertainly-e2e/tests/smoke/auth.smoke.spec.ts
+++ b/czertainly-e2e/tests/smoke/auth.smoke.spec.ts
@@ -37,7 +37,7 @@ test.describe('@smoke auth', () => {
 
       for (const item of sidebarItems) {
         await expect(
-          sidebarNav.getByRole(item.role, { name: item.name })
+          sidebarNav.getByRole(item.role, { name: item.name, exact: true })
         ).toBeVisible();
       }
     });

--- a/czertainly-e2e/tests/smoke/smokeData.ts
+++ b/czertainly-e2e/tests/smoke/smokeData.ts
@@ -13,7 +13,7 @@ export type NavigableSidebarItem = {
 
 export const sidebarItems: readonly SidebarItem[] = [
     { role: 'link', name: 'Dashboard', urlHint: /dashboard/i },
-    { role: 'link', name: 'Certificates', urlHint: /certificates/i },
+    { role: 'link', name: 'Certificates', urlHint: /\/certificates/i },
     { role: 'link', name: 'Keys', urlHint: /keys/i },
     { role: 'link', name: 'Discoveries', urlHint: /discoveries/i },
     { role: 'link', name: 'Connectors', urlHint: /connectors/i },


### PR DESCRIPTION
## Summary

- Added `exact: true` to sidebar role assertions in `auth.smoke.spec.ts` to prevent Playwright from matching both "Certificates" and "Trusted Certificates" links simultaneously
- Narrowed `urlHint` for Certificates from `/certificates/i` to `/\/certificates/i` so it does not match `/trustedcertificates` URLs

## Test plan

- [ ] Run SMK-001 (`auth.smoke.spec.ts`) — should pass without strict mode violation on "Certificates" locator
- [ ] Verify all other sidebar items still resolve correctly with `exact: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)