### PR TITLE
fix(smoke): update Dashboard navigation to sub-items structure

### DIFF
--- a/czertainly-e2e/tests/smoke/smokeData.ts
+++ b/czertainly-e2e/tests/smoke/smokeData.ts
@@ -12,7 +12,14 @@ export type NavigableSidebarItem = {
 };
 
 export const sidebarItems: readonly SidebarItem[] = [
-    { role: 'link', name: 'Dashboard', urlHint: /dashboard/i },
+    {
+        role: 'button',
+        name: 'Dashboard',
+        children: [
+            { role: 'link', name: 'Certificates Dashboard', urlHint: /\/dashboard\/certificates/i },
+            { role: 'link', name: 'Secrets Dashboard', urlHint: /\/dashboard\/secrets/i },
+        ],
+    },
     { role: 'link', name: 'Certificates', urlHint: /\/certificates/i },
     { role: 'link', name: 'Keys', urlHint: /keys/i },
     { role: 'link', name: 'Discoveries', urlHint: /discoveries/i },


### PR DESCRIPTION
## Summary

- Dashboard changes from a direct link to a collapsible button with two sub-items:
  - **Certificates Dashboard** → `/dashboard/certificates`
  - **Secrets Dashboard** → `/dashboard/secrets`

## Test plan

- [ ] Run SMK-001 (`auth.smoke.spec.ts`) — Dashboard button should be visible in sidebar
- [ ] Run SMK-002 (`navigation.smoke.spec.ts`) — both Certificates Dashboard and Secrets Dashboard should load without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)