### PR TITLE
fix(smoke): fix sidebar navigation stability and update sidebar items

### DIFF
--- a/czertainly-e2e/pages/Navigation.ts
+++ b/czertainly-e2e/pages/Navigation.ts
@@ -20,6 +20,7 @@ export class Navigation {
 
     if (await expandButton.isVisible()) {
       await expandButton.click();
+      await this.page.waitForTimeout(400);
       this.hasToggledSidebar = true;
     }
   }

--- a/czertainly-e2e/playwright.config.ts
+++ b/czertainly-e2e/playwright.config.ts
@@ -25,6 +25,8 @@ export default defineConfig({
   use: {
     baseURL: process.env.BASE_URL,
 
+    actionTimeout: 15_000,
+
     screenshot: 'only-on-failure',
 
     video: 'retain-on-failure',

--- a/czertainly-e2e/tests/smoke/smokeData.ts
+++ b/czertainly-e2e/tests/smoke/smokeData.ts
@@ -24,6 +24,8 @@ export const sidebarItems: readonly SidebarItem[] = [
     { role: 'link', name: 'Keys', urlHint: /keys/i },
     { role: 'link', name: 'Discoveries', urlHint: /discoveries/i },
     { role: 'link', name: 'Connectors', urlHint: /connectors/i },
+    { role: 'link', name: 'Secrets', urlHint: /\/secrets/i },
+    { role: 'link', name: 'CBOMs', urlHint: /\/cboms/i },
     {
         role: 'button',
         name: 'Access Control',
@@ -40,6 +42,7 @@ export const sidebarItems: readonly SidebarItem[] = [
             { role: 'link', name: 'Token Profiles', urlHint: /tokenprofiles/i },
             { role: 'link', name: 'Compliance Profiles', urlHint: /complianceprofiles/i },
             { role: 'link', name: 'Notification Profiles', urlHint: /notificationprofiles/i },
+            { role: 'link', name: 'Vault Profiles', urlHint: /vaultprofiles/i },
         ],
     },
     {
@@ -52,6 +55,7 @@ export const sidebarItems: readonly SidebarItem[] = [
             { role: 'link', name: 'Groups', urlHint: /groups/i },
             { role: 'link', name: 'Entities', urlHint: /entities/i },
             { role: 'link', name: 'Locations', urlHint: /locations/i },
+            { role: 'link', name: 'Vaults', urlHint: /\/vaults/i },
         ],
     },
     {


### PR DESCRIPTION
## Summary

- Add 400ms wait after sidebar toggle to let CSS animations settle before checking parent group expansion state — fixes Dashboard sub-items not expanding during navigation test
- Add global `actionTimeout: 15_000` to prevent single actions (e.g. blocked clicks) from consuming the entire test timeout
- Add new sidebar items to smoke data: **Secrets**, **CBOMs**, **Vault Profiles** (Profiles group), **Vaults** (Inventory group)

## Test plan

- [ ] Run SMK-001 (`auth.smoke.spec.ts`) — passes
- [ ] Run SMK-002 (`navigation.smoke.spec.ts`) — passes, Dashboard sub-items expand correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)