### PR TITLE
feat: add Testkube webhook payloads for Teams and Discord

### DIFF
--- a/testkube/notifications/discord-webhook-payload.json
+++ b/testkube/notifications/discord-webhook-payload.json
@@ -1,0 +1,19 @@
+{
+  "username": "Testkube QA Automation",
+  "content": "**Workflow:**: `{{ .TestWorkflowExecution.Workflow.Name }}`",
+  "embeds": [
+    {
+      "title": "Smoke result: {{ .TestWorkflowExecution.Result.Status | testworkflowstatustostring }}",
+      "url": "{{ .ExecutionURL }}",
+      "color": {{ if eq (.TestWorkflowExecution.Result.Status | testworkflowstatustostring) "passed" }}65280{{ else }}16711680{{ end }},
+      "fields": [
+        { "name": "Run #:", "value": "`{{ .TestWorkflowExecution.Number }}` ", "inline": true},
+        { "name": "Duration", "value": "{{ .TestWorkflowExecution.Result.Duration }}", "inline": true},
+        { "name": "Total tests", "value": "{{ (index .TestWorkflowExecution.Reports 0).Summary.Tests }}", "inline": true},
+        { "name": "Passed", "value": "{{ (index .TestWorkflowExecution.Reports 0).Summary.Passed }}", "inline": true},
+        { "name": "Failed", "value": "{{ (index .TestWorkflowExecution.Reports 0).Summary.Failed }}", "inline": true},
+        { "name": "Skipped", "value": "{{ (index .TestWorkflowExecution.Reports 0).Summary.Skipped }}", "inline": true}
+      ]
+    }
+  ]
+}

--- a/testkube/notifications/teams-webhook-payload.json
+++ b/testkube/notifications/teams-webhook-payload.json
@@ -1,0 +1,132 @@
+{
+  "type": "message",
+  "attachments": [
+    {
+      "contentType": "application/vnd.microsoft.card.adaptive",
+      "contentUrl": null,
+      "content": {
+        "type": "AdaptiveCard",
+        "$schema": "https://adaptivecards.io/schemas/adaptive-card.json",
+        "version": "1.6",
+        "body": [
+          {
+            "type": "ColumnSet",
+            "columns": [
+              {
+                "type": "Column",
+                "width": "auto",
+                "items": [
+                  {
+                    "type": "Icon",
+                    "name": "{{ if eq (.TestWorkflowExecution.Result.Status | testworkflowstatustostring) "passed" }}CheckmarkCircle{{ else }}DismissCircle{{ end }}",
+                    "color": "{{ if eq (.TestWorkflowExecution.Result.Status | testworkflowstatustostring) "passed" }}Good{{ else }}Attention{{ end }}",
+                    "style": "Filled",
+                    "size": "Large"
+                  }
+                ],
+                "verticalContentAlignment": "Center"
+              },
+              {
+                "type": "Column",
+                "width": "stretch",
+                "items": [
+                  {
+                    "type": "TextBlock",
+                    "text": "{{ if eq (.TestWorkflowExecution.Result.Status | testworkflowstatustostring) "passed" }}PASSED{{ else }}FAILED{{ end }}",
+                    "weight": "Bolder",
+                    "size": "Large",
+                    "color": "{{ if eq (.TestWorkflowExecution.Result.Status | testworkflowstatustostring) "passed" }}Good{{ else }}Attention{{ end }}"
+                  },
+                  {
+                    "type": "TextBlock",
+                    "text": "{{ .TestWorkflowExecution.Workflow.Name }}",
+                    "spacing": "None",
+                    "isSubtle": true
+                  }
+                ],
+                "verticalContentAlignment": "Center"
+              }
+            ]
+          },
+          {
+            "type": "Container",
+            "style": "emphasis",
+            "spacing": "Medium",
+            "items": [
+              {
+                "type": "ColumnSet",
+                "columns": [
+                  {
+                    "type": "Column",
+                    "width": "stretch",
+                    "items": [
+                      { "type": "TextBlock", "text": "Run #", "isSubtle": true, "size": "Small" },
+                      { "type": "TextBlock", "text": "{{ .TestWorkflowExecution.Number }}", "weight": "Bolder", "spacing": "None" }
+                    ]
+                  },
+                  {
+                    "type": "Column",
+                    "width": "stretch",
+                    "items": [
+                      { "type": "TextBlock", "text": "Duration", "isSubtle": true, "size": "Small" },
+                      { "type": "TextBlock", "text": "{{ .TestWorkflowExecution.Result.Duration }}", "weight": "Bolder", "spacing": "None" }
+                    ]
+                  },
+                  {
+                    "type": "Column",
+                    "width": "stretch",
+                    "items": [
+                      { "type": "TextBlock", "text": "Total", "isSubtle": true, "size": "Small" },
+                      { "type": "TextBlock", "text": "{{ (index .TestWorkflowExecution.Reports 0).Summary.Tests }}", "weight": "Bolder", "spacing": "None" }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "ColumnSet",
+                "spacing": "Small",
+                "columns": [
+                  {
+                    "type": "Column",
+                    "width": "stretch",
+                    "items": [
+                      { "type": "TextBlock", "text": "✅ Passed", "isSubtle": true, "size": "Small" },
+                      { "type": "TextBlock", "text": "{{ (index .TestWorkflowExecution.Reports 0).Summary.Passed }}", "weight": "Bolder", "color": "Good", "spacing": "None" }
+                    ]
+                  },
+                  {
+                    "type": "Column",
+                    "width": "stretch",
+                    "items": [
+                      { "type": "TextBlock", "text": "❌ Failed", "isSubtle": true, "size": "Small" },
+                      { "type": "TextBlock", "text": "{{ (index .TestWorkflowExecution.Reports 0).Summary.Failed }}", "weight": "Bolder", "color": "Attention", "spacing": "None" }
+                    ]
+                  },
+                  {
+                    "type": "Column",
+                    "width": "stretch",
+                    "items": [
+                      { "type": "TextBlock", "text": "⏭️ Skipped", "isSubtle": true, "size": "Small" },
+                      { "type": "TextBlock", "text": "{{ (index .TestWorkflowExecution.Reports 0).Summary.Skipped }}", "weight": "Bolder", "spacing": "None" }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "ActionSet",
+            "actions": [
+              {
+                "type": "Action.OpenUrl",
+                "title": "Open in Testkube",
+                "url": "{{ .ExecutionURL }}",
+                "iconUrl": "icon:ArrowUpRight"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/testkube/notifications/teams-webhook-payload.json
+++ b/testkube/notifications/teams-webhook-payload.json
@@ -10,118 +10,37 @@
         "version": "1.6",
         "body": [
           {
-            "type": "ColumnSet",
-            "columns": [
-              {
-                "type": "Column",
-                "width": "auto",
-                "items": [
-                  {
-                    "type": "Icon",
-                    "name": "{{ if eq (.TestWorkflowExecution.Result.Status | testworkflowstatustostring) "passed" }}CheckmarkCircle{{ else }}DismissCircle{{ end }}",
-                    "color": "{{ if eq (.TestWorkflowExecution.Result.Status | testworkflowstatustostring) "passed" }}Good{{ else }}Attention{{ end }}",
-                    "style": "Filled",
-                    "size": "Large"
-                  }
-                ],
-                "verticalContentAlignment": "Center"
-              },
-              {
-                "type": "Column",
-                "width": "stretch",
-                "items": [
-                  {
-                    "type": "TextBlock",
-                    "text": "{{ if eq (.TestWorkflowExecution.Result.Status | testworkflowstatustostring) "passed" }}PASSED{{ else }}FAILED{{ end }}",
-                    "weight": "Bolder",
-                    "size": "Large",
-                    "color": "{{ if eq (.TestWorkflowExecution.Result.Status | testworkflowstatustostring) "passed" }}Good{{ else }}Attention{{ end }}"
-                  },
-                  {
-                    "type": "TextBlock",
-                    "text": "{{ .TestWorkflowExecution.Workflow.Name }}",
-                    "spacing": "None",
-                    "isSubtle": true
-                  }
-                ],
-                "verticalContentAlignment": "Center"
-              }
-            ]
-          },
-          {
             "type": "Container",
-            "style": "emphasis",
-            "spacing": "Medium",
+            "style": "{{ if eq (.TestWorkflowExecution.Result.Status | testworkflowstatustostring) "passed" }}good{{ else }}attention{{ end }}",
             "items": [
               {
-                "type": "ColumnSet",
-                "columns": [
-                  {
-                    "type": "Column",
-                    "width": "stretch",
-                    "items": [
-                      { "type": "TextBlock", "text": "Run #", "isSubtle": true, "size": "Small" },
-                      { "type": "TextBlock", "text": "{{ .TestWorkflowExecution.Number }}", "weight": "Bolder", "spacing": "None" }
-                    ]
-                  },
-                  {
-                    "type": "Column",
-                    "width": "stretch",
-                    "items": [
-                      { "type": "TextBlock", "text": "Duration", "isSubtle": true, "size": "Small" },
-                      { "type": "TextBlock", "text": "{{ .TestWorkflowExecution.Result.Duration }}", "weight": "Bolder", "spacing": "None" }
-                    ]
-                  },
-                  {
-                    "type": "Column",
-                    "width": "stretch",
-                    "items": [
-                      { "type": "TextBlock", "text": "Total", "isSubtle": true, "size": "Small" },
-                      { "type": "TextBlock", "text": "{{ (index .TestWorkflowExecution.Reports 0).Summary.Tests }}", "weight": "Bolder", "spacing": "None" }
-                    ]
-                  }
+                "type": "TextBlock",
+                "text": "{{ if eq (.TestWorkflowExecution.Result.Status | testworkflowstatustostring) "passed" }}✅ PASSED{{ else }}🚨 FAILED{{ end }}",
+                "wrap": true,
+                "style": "heading",
+                "weight": "Bolder"
+              },
+              {
+                "type": "FactSet",
+                "facts": [
+                  { "title": "Workflow:", "value": "{{ .TestWorkflowExecution.Workflow.Name }}" },
+                  { "title": "Run #:", "value": "{{ .TestWorkflowExecution.Number }}" },
+                  { "title": "Duration:", "value": "{{ .TestWorkflowExecution.Result.Duration }}" },
+                  { "title": "Total tests:", "value": "{{ (index .TestWorkflowExecution.Reports 0).Summary.Tests }}" },
+                  { "title": "Passed:", "value": "{{ (index .TestWorkflowExecution.Reports 0).Summary.Passed }}" },
+                  { "title": "Failed:", "value": "{{ (index .TestWorkflowExecution.Reports 0).Summary.Failed }}" },
+                  { "title": "Skipped:", "value": "{{ (index .TestWorkflowExecution.Reports 0).Summary.Skipped }}" }
                 ]
               },
               {
-                "type": "ColumnSet",
-                "spacing": "Small",
-                "columns": [
+                "type": "ActionSet",
+                "actions": [
                   {
-                    "type": "Column",
-                    "width": "stretch",
-                    "items": [
-                      { "type": "TextBlock", "text": "✅ Passed", "isSubtle": true, "size": "Small" },
-                      { "type": "TextBlock", "text": "{{ (index .TestWorkflowExecution.Reports 0).Summary.Passed }}", "weight": "Bolder", "color": "Good", "spacing": "None" }
-                    ]
-                  },
-                  {
-                    "type": "Column",
-                    "width": "stretch",
-                    "items": [
-                      { "type": "TextBlock", "text": "❌ Failed", "isSubtle": true, "size": "Small" },
-                      { "type": "TextBlock", "text": "{{ (index .TestWorkflowExecution.Reports 0).Summary.Failed }}", "weight": "Bolder", "color": "Attention", "spacing": "None" }
-                    ]
-                  },
-                  {
-                    "type": "Column",
-                    "width": "stretch",
-                    "items": [
-                      { "type": "TextBlock", "text": "⏭️ Skipped", "isSubtle": true, "size": "Small" },
-                      { "type": "TextBlock", "text": "{{ (index .TestWorkflowExecution.Reports 0).Summary.Skipped }}", "weight": "Bolder", "spacing": "None" }
-                    ]
+                    "type": "Action.OpenUrl",
+                    "title": "Open in Testkube",
+                    "url": "{{ .ExecutionURL }}"
                   }
                 ]
-              }
-            ]
-          },
-          {
-            "type": "ActionSet",
-            "actions": [
-              {
-                "type": "Action.OpenUrl",
-                "title": "Open in Testkube",
-                "url": "{{ .ExecutionURL }}",
-                "iconUrl": "icon:ArrowUpRight"
               }
             ]
           }


### PR DESCRIPTION
## Summary
- Add `testkube/notifications/teams-webhook-payload.json` — Adaptive Card payload for Microsoft Teams
- Add `testkube/notifications/discord-webhook-payload.json` — embed payload for Discord

## Notes
Both payloads use Testkube Go template variables and are configured for the `playwright-smoke` workflow on the `qa/automation-env` environment.