### PR TITLE
fix: update auth realm defaults and fix discovery polling race condition

### DIFF
--- a/czertainly-e2e/pages/DiscoveryPage.ts
+++ b/czertainly-e2e/pages/DiscoveryPage.ts
@@ -118,7 +118,10 @@ export class DiscoveryPage {
             await this.page.reload();
             await expect(this.main).toBeVisible();
 
-            if (await this.providerStatusRow.isVisible() && await this.statusRow.isVisible()) {
+            try {
+                await expect(this.providerStatusRow).toBeVisible({ timeout: 5000 });
+                await expect(this.statusRow).toBeVisible({ timeout: 5000 });
+
                 const providerStatusBadge = this.providerStatusRow.locator('[data-testid="badge"]');
                 const statusBadge = this.statusRow.locator('[data-testid="badge"]');
 
@@ -126,8 +129,9 @@ export class DiscoveryPage {
                 const statusText = (await statusBadge.textContent())?.trim();
 
                 return providerText === 'Completed' && statusText === 'Completed';
+            } catch {
+                return false;
             }
-            return false;
         }, {
             message: 'Discovery did not reach Completed status',
             timeout: timeout,

--- a/czertainly-e2e/utils/env.ts
+++ b/czertainly-e2e/utils/env.ts
@@ -38,8 +38,8 @@ export function loadEnv(): TestEnv {
     username: required('SMOKE_USERNAME'),
     password: required('SMOKE_PASSWORD'),
     clientSecret: process.env.SMOKE_CLIENT_SECRET,
-    authClientId: process.env.AUTH_CLIENT_ID || 'czertainly',
-    authRealm: process.env.AUTH_REALM || 'CZERTAINLY',
+    authClientId: process.env.AUTH_CLIENT_ID || 'ilm',
+    authRealm: process.env.AUTH_REALM || 'ILM',
     authBaseUrl: process.env.AUTH_BASE_URL, // Defaults to baseUrl/kc if not set
     localAuthProviderName: required('LOCAL_AUTH_PROVIDER_NAME'),
     discoveryProviderUrl: process.env.DISCOVERY_PROVIDER_URL,


### PR DESCRIPTION
## Summary

- Update `authClientId` and `authRealm` defaults from `czertainly`/`CZERTAINLY` to `ilm`/`ILM` to match current Keycloak realm configuration
- Fix race condition in `DiscoveryPage.waitForCompletion`: replace point-in-time `isVisible()` check with `toBeVisible({ timeout: 5000 })` after page reload, preventing false negatives when the page hasn't fully loaded yet

## Test plan

- [x] All 3 smoke tests pass locally in headless mode
- [x] Discovery test passes in headed mode with no spurious reloads after completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)