### PR TITLE
fix(smoke): scope History tab match exactly and cover Event History

### DIFF
--- a/czertainly-e2e/pages/DiscoveryPage.ts
+++ b/czertainly-e2e/pages/DiscoveryPage.ts
@@ -151,7 +151,7 @@ export class DiscoveryPage {
         const tablist = this.page.getByRole('tablist');
         if (await tablist.isVisible()) {
             for (const tabName of CERTIFICATE_DETAILS_TABS) {
-                const tab = tablist.getByRole('tab', { name: tabName });
+                const tab = tablist.getByRole('tab', { name: tabName, exact: true });
                 if (await tab.isVisible()) {
                     await tab.click();
                     await expect(this.page.locator('main')).not.toContainText(/internal server error/i);

--- a/czertainly-e2e/utils/constants.ts
+++ b/czertainly-e2e/utils/constants.ts
@@ -14,6 +14,7 @@ export const CERTIFICATE_DETAILS_TABS = [
     'Approvals',
     'Locations',
     'History',
+    'Event History',
     'Flow',
     'Related Certificates',
 ];


### PR DESCRIPTION
## Summary
- Event Viewer epic added an **Event History** tab to the certificate details page, which broke SMK-003: `getByRole('tab', { name: 'History' })` matched both `History` and `Event History` under Playwright strict mode.
- Added `exact: true` to the tab locator in `DiscoveryPage.openCertificateDetailsAndVerify` so `History` no longer collides with `Event History`.
- Added `Event History` to `CERTIFICATE_DETAILS_TABS` so the new tab is smoke-covered (click + no 500 / error text).

## Test plan
- [x] `npx playwright test tests/smoke/discovery.smoke.spec.ts` — SMK-003 green
- [x] `npx playwright test tests/smoke` — all 3 smoke tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)