### PR TITLE
fix(smoke): adapt suite to FE rename + auto-provision connectors

### DIFF
--- a/czertainly-e2e/.env.example
+++ b/czertainly-e2e/.env.example
@@ -14,18 +14,34 @@ AUTH_REALM=
 AUTH_BASE_URL=
 LOCAL_AUTH_PROVIDER_NAME=Internal
 
-# === SMK-003: Network Discovery (optional — test skips if absent) ===
+# === Smoke mode ===
+# Default (unset / =false): hermetic — globalSetup provisions per-run and
+#   globalTeardown deletes everything. Right for CI.
+# SMOKE_PERSIST=true: reuse mode for local iterative dev. First run provisions
+#   and writes .smoke-state.json. Subsequent runs see the state file and skip
+#   provisioning. globalTeardown is also skipped — state persists. When done,
+#   manually delete .smoke-state.json (and clean entities in Core if needed).
+#   NOTE: every smoke env var below must still be set — SMOKE_PERSIST only
+#   affects state reuse, not validation.
+SMOKE_PERSIST=
+
+# === SMK-003: Network Discovery ===
+DISCOVERY_PROVIDER_NAME=Network Discovery Provider
 DISCOVERY_PROVIDER_URL=
 DISCOVERY_TARGET=
-DISCOVERY_PROVIDER_NAME=
 
-# === SMK-004: Certificate Issuance (optional — test skips if absent) ===
+# === SMK-004: Certificate Issuance ===
 # Test creates Credential + Authority + RA Profile + Certificate per-run via API.
-# Assumes connector pods are deployed and registered in Core (env-bootstrap, not part of test).
+# Connector pods are auto-registered in Core if missing (handles cluster rebuilds).
 
-# Connector names (have defaults in code — leave empty to use defaults)
-EJBCA_CONNECTOR_NAME=
-CREDENTIAL_CONNECTOR_NAME=
+EJBCA_CONNECTOR_NAME=EJBCA-NG-Connector
+CREDENTIAL_CONNECTOR_NAME=Common-Credential-Connector
+
+# Connector pod URLs (required) — cluster-internal Kubernetes Service URLs of the
+# connector pods. Used to auto-register the connectors in ILM Core if missing
+# (after cluster rebuild).
+EJBCA_CONNECTOR_URL=
+CREDENTIAL_CONNECTOR_URL=
 
 # EJBCA target — required when running SMK-004
 # Format: https://<host>/ejbca/ejbcaws/ejbcaws?wsdl

--- a/czertainly-e2e/global-setup.ts
+++ b/czertainly-e2e/global-setup.ts
@@ -1,16 +1,21 @@
 /**
- * Playwright globalSetup for SMK-004.
+ * Playwright globalSetup for the smoke suite.
  *
- * Runs ONCE before any tests. If SMK-004 env vars are all present, provisions
- * the per-run PKI chain via Core REST API:
- *   1. Authenticates to Keycloak → APIRequestContext with Bearer token
- *   2. Looks up EJBCA + Credential connectors by name
- *   3. Creates Credential (from P12 in env), Authority, RA Profile (+ enable)
- *   4. Writes UUIDs to .smoke-state.json for the test + globalTeardown
+ * Runs ONCE before any tests. By the time we get here, loadEnv() has guaranteed
+ * every smoke env var is present (strict validation in env.ts).
  *
- * If env vars are missing → silently skip (no-op). SMK-004 test then skips itself.
- * If any creation step fails → best-effort cleanup of partial state, then re-throw
- * (causes Playwright to fail all tests, which is correct — env is broken).
+ * Default mode (SMOKE_PERSIST not set): full provisioning every run.
+ *   1. Authenticate against Keycloak
+ *   2. Register all 3 connectors (auto-register if missing)
+ *   3. Create per-run PKI chain (Credential + Authority + RA Profile)
+ *   4. Write UUIDs to .smoke-state.json
+ *
+ * Persistent mode (SMOKE_PERSIST=true) for local iterative dev:
+ *   - If .smoke-state.json already exists → log "reusing" + return (no provisioning)
+ *   - Otherwise → full provisioning as above; state file persists for next run
+ *
+ * If any provisioning step fails → best-effort cleanup of partial state, then
+ * re-throw → Playwright fails all tests (env is broken).
  */
 
 import { FullConfig, request as playwrightRequest } from '@playwright/test';
@@ -20,7 +25,7 @@ import * as connectorUtils from './utils/connectorUtils';
 import * as credentialUtils from './utils/credentialUtils';
 import * as authorityUtils from './utils/authorityUtils';
 import * as raProfileUtils from './utils/raProfileUtils';
-import { writeSmokeState } from './utils/smokeState';
+import { readSmokeState, writeSmokeState } from './utils/smokeState';
 import { Logger } from './utils/Logger';
 
 const logger = new Logger('GlobalSetup');
@@ -28,76 +33,81 @@ const logger = new Logger('GlobalSetup');
 export default async function globalSetup(_config: FullConfig): Promise<void> {
     const env = loadEnv();
 
-    // SMK-004 needs ALL these vars. If any missing → skip provisioning.
-    // SMK-004 test will then skip itself (state file doesn't exist).
-    const required: Record<string, string | undefined> = {
-        EJBCA_WS_URL: env.ejbcaWsUrl,
-        EJBCA_P12_BASE64: env.ejbcaP12Base64,
-        EJBCA_P12_PASSWORD: env.ejbcaP12Password,
-        EJBCA_CA_NAME: env.ejbcaCaName,
-        EJBCA_END_ENTITY_PROFILE: env.ejbcaEndEntityProfile,
-        EJBCA_CERTIFICATE_PROFILE: env.ejbcaCertificateProfile,
-    };
-    const missing = Object.entries(required).filter(([, v]) => !v).map(([k]) => k);
-    if (missing.length > 0) {
-        logger.info(`SMK-004 env vars missing: ${missing.join(', ')} — skipping per-run provisioning`);
+    // Persistent mode: if state already exists, reuse it and skip provisioning.
+    if (env.smokePersist && readSmokeState()) {
+        logger.info('SMOKE_PERSIST=true and state file exists — reusing fixtures, skipping provisioning.');
         return;
     }
 
-    // 1. Build authenticated API context (Keycloak ROPC → Bearer token)
     const baseRequest = await playwrightRequest.newContext({
         baseURL: env.baseUrl,
         ignoreHTTPSErrors: true,
     });
     const api = await getAuthenticatedApiContext(baseRequest, env);
 
-    // Track what we've created — for partial cleanup if next step fails
+    const registeredConnectorUuids: string[] = [];
     let credentialUuid: string | undefined;
     let authorityUuid: string | undefined;
     let raProfileUuid: string | undefined;
 
     try {
-        // 2. Find both connectors by name
-        const ejbcaConnector = await connectorUtils.findConnectorByName(api, env.ejbcaConnectorName);
-        const credConnector = await connectorUtils.findConnectorByName(api, env.credentialConnectorName);
+        // 1. Register all 3 connectors (idempotent — finds existing or creates)
+        const discoveryResult = await connectorUtils.ensureConnectorRegistered(api, {
+            name: env.smoke.discoveryProviderName!,
+            url: env.smoke.discoveryProviderUrl!,
+        });
+        if (discoveryResult.registered) registeredConnectorUuids.push(discoveryResult.connector.uuid);
+
+        const ejbcaResult = await connectorUtils.ensureConnectorRegistered(api, {
+            name: env.smoke.ejbcaConnectorName!,
+            url: env.smoke.ejbcaConnectorUrl!,
+        });
+        if (ejbcaResult.registered) registeredConnectorUuids.push(ejbcaResult.connector.uuid);
+
+        const credResult = await connectorUtils.ensureConnectorRegistered(api, {
+            name: env.smoke.credentialConnectorName!,
+            url: env.smoke.credentialConnectorUrl!,
+        });
+        if (credResult.registered) registeredConnectorUuids.push(credResult.connector.uuid);
 
         const timestamp = Date.now();
 
-        // 3. Create Credential (with P12 + password from env)
+        // 2. Create Credential (with P12 + password from env)
         const credentialName = `smoke-credential-${timestamp}`;
         const credential = await credentialUtils.createCredential(api, {
             name: credentialName,
-            connectorUuid: credConnector.uuid,
-            p12Base64: env.ejbcaP12Base64!,
-            password: env.ejbcaP12Password!,
+            connectorUuid: credResult.connector.uuid,
+            p12Base64: env.smoke.ejbcaP12Base64!,
+            password: env.smoke.ejbcaP12Password!,
         });
         credentialUuid = credential.uuid;
 
-        // 4. Create Authority (refs Credential + WS URL)
+        // 3. Create Authority (refs Credential + WS URL)
         const authorityName = `smoke-authority-${timestamp}`;
         const authority = await authorityUtils.createAuthority(api, {
             name: authorityName,
-            connectorUuid: ejbcaConnector.uuid,
-            wsUrl: env.ejbcaWsUrl!,
+            connectorUuid: ejbcaResult.connector.uuid,
+            wsUrl: env.smoke.ejbcaWsUrl!,
             credential: { uuid: credential.uuid, name: credential.name },
         });
         authorityUuid = authority.uuid;
 
-        // 5. Create RA Profile + enable
+        // 4. Create RA Profile + enable
         const raProfileName = `smoke-raprofile-${timestamp}`;
         const raProfile = await raProfileUtils.createRaProfile(api, {
             name: raProfileName,
             authorityUuid: authority.uuid,
-            endEntityProfileName: env.ejbcaEndEntityProfile!,
-            certificateProfileName: env.ejbcaCertificateProfile!,
-            caName: env.ejbcaCaName!,
+            endEntityProfileName: env.smoke.ejbcaEndEntityProfile!,
+            certificateProfileName: env.smoke.ejbcaCertificateProfile!,
+            caName: env.smoke.ejbcaCaName!,
             usernamePrefix: 'atf-',
         });
         raProfileUuid = raProfile.uuid;
         await raProfileUtils.enableRaProfile(api, authority.uuid, raProfile.uuid);
 
-        // 6. Write state file for the test + globalTeardown
+        // 5. Write state file for the tests + globalTeardown
         writeSmokeState({
+            registeredConnectorUuids,
             credentialUuid: credential.uuid, credentialName,
             authorityUuid: authority.uuid, authorityName,
             raProfileUuid: raProfile.uuid, raProfileName,
@@ -107,7 +117,7 @@ export default async function globalSetup(_config: FullConfig): Promise<void> {
     } catch (e) {
         logger.error('globalSetup failed, attempting partial cleanup:', e);
 
-        // Reverse order — RA Profile depends on Authority, Authority depends on Credential
+        // Reverse dependency order
         if (raProfileUuid && authorityUuid) {
             try { await raProfileUtils.deleteRaProfile(api, authorityUuid, raProfileUuid); }
             catch (err) { logger.warn(`Partial cleanup: deleteRaProfile failed: ${err}`); }
@@ -119,6 +129,10 @@ export default async function globalSetup(_config: FullConfig): Promise<void> {
         if (credentialUuid) {
             try { await credentialUtils.deleteCredential(api, credentialUuid); }
             catch (err) { logger.warn(`Partial cleanup: deleteCredential failed: ${err}`); }
+        }
+        for (const uuid of registeredConnectorUuids) {
+            try { await connectorUtils.deleteConnector(api, uuid); }
+            catch (err) { logger.warn(`Partial cleanup: deleteConnector ${uuid} failed: ${err}`); }
         }
 
         throw e;  // re-throw → Playwright fails all tests

--- a/czertainly-e2e/global-teardown.ts
+++ b/czertainly-e2e/global-teardown.ts
@@ -1,17 +1,23 @@
 /**
- * Playwright globalTeardown for SMK-004.
+ * Playwright globalTeardown for the smoke suite.
  *
- * Runs ONCE after all tests. Reads .smoke-state.json (written by globalSetup)
- * and deletes the provisioned PKI chain in reverse dependency order:
- *   RA Profile → Authority → Credential → state file
+ * Default mode: reads .smoke-state.json and deletes everything globalSetup created,
+ * in reverse dependency order:
+ *   RA Profile → Authority → Credential → registered connectors → state file
+ * Only connectors THIS run registered (tracked by globalSetup) are deleted —
+ * pre-existing connectors are left untouched so we don't break manual work.
  *
- * No-op if state file doesn't exist (globalSetup skipped or failed before writing).
- * Each delete is best-effort (try/catch + warn) — one failure doesn't block the others.
+ * Persistent mode (SMOKE_PERSIST=true): skip entirely — leave state file and
+ * provisioned entities in place for the next local run to reuse. Dev cleans up
+ * manually when done iterating (delete .smoke-state.json + entities in UI/API).
+ *
+ * No-op if the state file doesn't exist. Each delete is best-effort (try/catch + warn).
  */
 
 import { FullConfig, request as playwrightRequest } from '@playwright/test';
 import { loadEnv } from './utils/env';
 import { getAuthenticatedApiContext } from './fixtures/testFixtures';
+import * as connectorUtils from './utils/connectorUtils';
 import * as credentialUtils from './utils/credentialUtils';
 import * as authorityUtils from './utils/authorityUtils';
 import * as raProfileUtils from './utils/raProfileUtils';
@@ -21,13 +27,18 @@ import { Logger } from './utils/Logger';
 const logger = new Logger('GlobalTeardown');
 
 export default async function globalTeardown(_config: FullConfig): Promise<void> {
+    const env = loadEnv();
+
+    if (env.smokePersist) {
+        logger.info('SMOKE_PERSIST=true — preserving state file and provisioned entities for next run.');
+        return;
+    }
+
     const state = readSmokeState();
     if (!state) {
         logger.info('No smoke state file — nothing to clean up');
         return;
     }
-
-    const env = loadEnv();
     const baseRequest = await playwrightRequest.newContext({
         baseURL: env.baseUrl,
         ignoreHTTPSErrors: true,
@@ -35,15 +46,25 @@ export default async function globalTeardown(_config: FullConfig): Promise<void>
     const api = await getAuthenticatedApiContext(baseRequest, env);
 
     try {
-        // Reverse dependency order: RA Profile → Authority → Credential
-        try { await raProfileUtils.deleteRaProfile(api, state.authorityUuid, state.raProfileUuid); }
-        catch (e) { logger.warn(`Teardown: deleteRaProfile failed: ${e}`); }
+        // PKI chain — only if it was provisioned (SMK-004 path)
+        if (state.raProfileUuid && state.authorityUuid) {
+            try { await raProfileUtils.deleteRaProfile(api, state.authorityUuid, state.raProfileUuid); }
+            catch (e) { logger.warn(`Teardown: deleteRaProfile failed: ${e}`); }
+        }
+        if (state.authorityUuid) {
+            try { await authorityUtils.deleteAuthority(api, state.authorityUuid); }
+            catch (e) { logger.warn(`Teardown: deleteAuthority failed: ${e}`); }
+        }
+        if (state.credentialUuid) {
+            try { await credentialUtils.deleteCredential(api, state.credentialUuid); }
+            catch (e) { logger.warn(`Teardown: deleteCredential failed: ${e}`); }
+        }
 
-        try { await authorityUtils.deleteAuthority(api, state.authorityUuid); }
-        catch (e) { logger.warn(`Teardown: deleteAuthority failed: ${e}`); }
-
-        try { await credentialUtils.deleteCredential(api, state.credentialUuid); }
-        catch (e) { logger.warn(`Teardown: deleteCredential failed: ${e}`); }
+        // Connectors WE registered this run — only these, never pre-existing ones
+        for (const uuid of state.registeredConnectorUuids) {
+            try { await connectorUtils.deleteConnector(api, uuid); }
+            catch (e) { logger.warn(`Teardown: deleteConnector ${uuid} failed: ${e}`); }
+        }
 
         deleteSmokeState();
         logger.info(`globalTeardown complete`);

--- a/czertainly-e2e/pages/LoginPage.ts
+++ b/czertainly-e2e/pages/LoginPage.ts
@@ -29,7 +29,9 @@ export class LoginPage {
       logger.info('Login form visible immediately. Skipping provider selection.');
     } catch {
       const providerName = this.env.localAuthProviderName ?? 'Internal';
-      const providerBtn = this.page.getByText(providerName);
+      // Scope by role + exact name — partial text match collides on envs with
+      // multiple "Internal*" identity providers (e.g. Internal, Internal2, Internal-userinfo).
+      const providerBtn = this.page.getByRole('button', { name: providerName, exact: true });
 
       logger.info(`Login form not visible. Expecting provider selection: "${providerName}"`);
       await expect(providerBtn, `Provider "${providerName}" button should be visible`).toBeVisible();

--- a/czertainly-e2e/pages/Navigation.ts
+++ b/czertainly-e2e/pages/Navigation.ts
@@ -54,19 +54,33 @@ export class Navigation {
   ): Promise<void> {
     await this.ensureSidebarExpanded();
 
+    let targetLink: Locator;
+
     if (parentButtonName) {
       const parentButton = this.sidebarNav.getByRole('button', {
         name: parentButtonName,
         exact: true,
       });
-
       await this.ensureParentExpanded(parentButton);
-    }
 
-    const targetLink = this.sidebarNav.getByRole('link', {
-      name: menuText,
-      exact: true,
-    });
+      // Scope link search to the parent's children <ul>. This avoids matching
+      // duplicate names that live elsewhere in the sidebar (e.g. Dashboard >
+      // Certificates vs top-level Certificates after the 2026-06 FE rename).
+      const parentContainer = parentButton.locator('..');
+      const childrenList = parentContainer.locator('ul').first();
+      targetLink = childrenList.getByRole('link', {
+        name: menuText,
+        exact: true,
+      });
+    } else {
+      // Top-level link: scope to direct-child <li> of the sidebar's main <ul>,
+      // which excludes nested submenu links with the same name. Structural
+      // (CSS direct-child `>`), not DOM-order dependent — safer than .last().
+      const topLevelUl = this.sidebarNav.locator('ul').first();
+      targetLink = topLevelUl.locator(':scope > li').locator('> a, > div > a').filter({
+        hasText: menuText,
+      });
+    }
 
     await Promise.all([
       this.page.waitForURL(urlHint, { waitUntil: 'domcontentloaded' }),

--- a/czertainly-e2e/pages/TablePage.ts
+++ b/czertainly-e2e/pages/TablePage.ts
@@ -12,6 +12,13 @@ export class TablePage {
     readonly confirmModal: Locator;
     readonly confirmDeleteButton: Locator;
 
+    // Filter row controls — appear on every list page (Connectors, Keys, Certificates, …).
+    readonly filterGroupTrigger: Locator;
+    readonly filterFieldTrigger: Locator;
+    readonly filterConditionsTrigger: Locator;
+    readonly filterValueInput: Locator;
+    readonly addFilterButton: Locator;
+
     constructor(page: Page) {
         this.page = page;
         this.table = page.locator('table');
@@ -20,6 +27,13 @@ export class TablePage {
         this.deleteButton = page.locator('button').filter({ has: page.locator('svg.lucide-trash-2') }).first();
         this.confirmModal = page.locator('div[role="dialog"]');
         this.confirmDeleteButton = this.confirmModal.locator('button').filter({ hasText: /delete|confirm|yes/i }).first();
+
+        const main = page.locator('main');
+        this.filterGroupTrigger = main.getByTestId('select-group-trigger');
+        this.filterFieldTrigger = main.getByTestId('select-field-trigger');
+        this.filterConditionsTrigger = main.getByTestId('select-conditions-trigger');
+        this.filterValueInput = main.getByTestId('text-input-valueSelect');
+        this.addFilterButton = main.locator('#addFilter');
     }
 
     async visit(url: string) {
@@ -43,6 +57,29 @@ export class TablePage {
         if (firstRowText?.includes('No data')) return false;
 
         return true;
+    }
+
+    /**
+     * Apply a Filter row (Group → Field → Condition → Value) to surface a row
+     * in a large/paginated list. Filter dropdowns are sequentially gated — each
+     * becomes enabled only after the previous is set. The Value input is readonly
+     * until clicked, so we click before fill.
+     */
+    async applyFilter(opts: { group: string; field: string; condition: string; value: string }): Promise<void> {
+        const pickOption = async (trigger: Locator, label: string, optionLabel: string) => {
+            await expect(trigger, `Filter ${label} trigger should be enabled`).toBeEnabled();
+            await trigger.click();
+            const option = this.page.getByRole('option', { name: optionLabel, exact: true });
+            await option.waitFor({ state: 'visible' });
+            await option.click();
+        };
+        await pickOption(this.filterGroupTrigger, 'Group', opts.group);
+        await pickOption(this.filterFieldTrigger, 'Field', opts.field);
+        await pickOption(this.filterConditionsTrigger, 'Condition', opts.condition);
+
+        await this.filterValueInput.click();  // focus first — FE removes readonly on focus
+        await this.filterValueInput.fill(opts.value);
+        await this.addFilterButton.click();
     }
 
     async bulkDelete(logName: string) {

--- a/czertainly-e2e/tests/smoke/auth.smoke.spec.ts
+++ b/czertainly-e2e/tests/smoke/auth.smoke.spec.ts
@@ -33,11 +33,15 @@ test.describe('@smoke auth', () => {
     });
 
     await test.step('assert sidebar items', async () => {
-
-
+      // Scope to direct-child <a>/<button> of the main <ul>, so nested links inside
+      // expanded parent menus (e.g. Dashboard > Certificates) don't collide with
+      // top-level items of the same name (e.g. top-level Certificates).
+      const topLevelUl = sidebarNav.locator('ul').first();
       for (const item of sidebarItems) {
+        const tag = item.role === 'link' ? 'a' : 'button';
         await expect(
-          sidebarNav.getByRole(item.role, { name: item.name, exact: true })
+          topLevelUl.locator(`:scope > li > ${tag}, :scope > li > div > ${tag}`)
+            .filter({ hasText: item.name })
         ).toBeVisible();
       }
     });

--- a/czertainly-e2e/tests/smoke/certificate.smoke.spec.ts
+++ b/czertainly-e2e/tests/smoke/certificate.smoke.spec.ts
@@ -1,5 +1,5 @@
 import {
-    test, expect,
+    test,
     loginAsSmokeUser, getAuthenticatedApiContext,
 } from '../../fixtures/testFixtures';
 import { CertificatePage } from '../../pages/CertificatePage';
@@ -52,7 +52,10 @@ test.describe('@smoke certificate', () => {
         test.setTimeout(60_000); // 1 minute — realistic path is ~40s; tighter than this risks flakes
 
         const state = readSmokeState();
-        test.skip(!state, 'SMK-004 fixtures not provisioned (env vars missing) — globalSetup skipped');
+        if (!state) {
+            test.skip(true, 'SMK-004 fixtures not provisioned (env vars missing) — globalSetup skipped');
+            return;  // narrows `state` to SmokeState below
+        }
 
         const certPage = new CertificatePage(page);
         const cn = `qa-smoke-test-${Date.now()}.example.com`;
@@ -66,7 +69,7 @@ test.describe('@smoke certificate', () => {
 
         await test.step('Issue certificate via UI', async () => {
             await certPage.openIssuePage();
-            await certPage.selectRaProfile(state!.raProfileName);
+            await certPage.selectRaProfile(state.raProfileName);
             await certPage.selectKeySourceExternal();
             await certPage.pasteCsr(csr);
             issuedCertUuid = await certPage.submitIssue();
@@ -86,7 +89,7 @@ test.describe('@smoke certificate', () => {
         await test.step('Verify Details tab', async () => {
             await certPage.assertDetailsTab({
                 commonName: cn,
-                raProfileName: state!.raProfileName,
+                raProfileName: state.raProfileName,
                 ownerName: env.username,
             });
         });

--- a/czertainly-e2e/tests/smoke/discovery.smoke.spec.ts
+++ b/czertainly-e2e/tests/smoke/discovery.smoke.spec.ts
@@ -4,6 +4,7 @@ import { TablePage } from '../../pages/TablePage';
 import { DiscoveryPage } from '../../pages/DiscoveryPage';
 import * as connectorUtils from '../../utils/connectorUtils';
 import { waitForDiscoveryCompletion } from '../../utils/discoveryUtils';
+import { readSmokeState } from '../../utils/smokeState';
 import { Logger } from '../../utils/Logger';
 
 const logger = new Logger('DiscoverySmokeTest');
@@ -12,6 +13,10 @@ const DISCOVERY_TIMEOUT_MS = 60_000; // Was 300_000 (5min); discoveries actually
 
 test.describe('@smoke discovery', () => {
   test.afterEach(async ({ page }) => {
+    // Test self-skips when smoke state file is missing — nothing was created, nothing to clean.
+    // Guard prevents afterEach from hitting the platform unauthenticated and timing out on a login redirect.
+    if (!readSmokeState()) return;
+
     const tablePage = new TablePage(page);
 
     const cleanupEntity = async (url: string, name: string) => {
@@ -30,25 +35,22 @@ test.describe('@smoke discovery', () => {
 
   test('SMK-003: network discovery and certificate details', async ({ page, request, env }) => {
     test.setTimeout(360000);
-    test.skip(
-      !env.discoveryProviderName || !env.discoveryTarget,
-      'DISCOVERY_PROVIDER_NAME and DISCOVERY_TARGET are required.'
-    );
+    test.skip(!readSmokeState(), 'Smoke fixtures not provisioned (env vars missing) — globalSetup skipped');
 
     // --- Step 0: Find existing Connector (Pre-condition) ---
-    if (env.discoveryProviderUrl) {
+    if (env.smoke.discoveryProviderUrl) {
       await test.step('Find & Approve existing connector', async () => {
-        logger.info(`Looking for connector with URL: ${env.discoveryProviderUrl}`);
+        logger.info(`Looking for connector with URL: ${env.smoke.discoveryProviderUrl}`);
 
         const apiRequest = await getAuthenticatedApiContext(request, env);
 
         try {
           const connectors = await connectorUtils.getAllConnectors(apiRequest);
-          const foundConnector = connectors.find(c => c.url === env.discoveryProviderUrl);
+          const foundConnector = connectors.find(c => c.url === env.smoke.discoveryProviderUrl);
 
           if (!foundConnector) {
             logger.debug(`Available connectors: ${connectors.map(c => `${c.name} (${c.url})`).join(', ')}`);
-            throw new Error(`Connector with URL ${env.discoveryProviderUrl} not found in the system.`);
+            throw new Error(`Connector with URL ${env.smoke.discoveryProviderUrl} not found in the system.`);
           }
 
           logger.info(`Found connector: ${foundConnector.name} (UUID: ${foundConnector.uuid}, Status: ${foundConnector.status})`);
@@ -60,7 +62,7 @@ test.describe('@smoke discovery', () => {
             await connectorUtils.checkConnectorHealth(apiRequest, foundConnector.uuid);
           }
 
-          env.discoveryProviderName = foundConnector.name;
+          env.smoke.discoveryProviderName = foundConnector.name;
           logger.info(`Using connector: ${foundConnector.name}`);
 
         } catch (error) {
@@ -82,18 +84,18 @@ test.describe('@smoke discovery', () => {
       const main = page.locator('main');
       await expect(main).toBeVisible();
 
-      const providerRow = main.getByRole('row', { name: env.discoveryProviderName! }).first();
+      // Surface the discovery connector via the page's filter — the table may
+      // hold many connectors and paginate.
+      const tablePage = new TablePage(page);
+      await tablePage.applyFilter({
+        group: 'Property',
+        field: 'Name',
+        condition: 'contains',
+        value: env.smoke.discoveryProviderName!,
+      });
 
-      const searchInput = main.locator('input[placeholder="Search"], input#search').first();
-      if (await searchInput.isVisible()) {
-        await searchInput.fill(env.discoveryProviderName!);
-        await searchInput.press('Enter');
-        await expect(async () => {
-          await expect(providerRow).toBeVisible();
-        }).toPass();
-      }
-      await expect(providerRow, `Provider "${env.discoveryProviderName}" should be visible in Connectors list`).toBeVisible();
-
+      const providerRow = main.getByRole('row', { name: env.smoke.discoveryProviderName! }).first();
+      await expect(providerRow, `Provider "${env.smoke.discoveryProviderName}" should be visible in Connectors list`).toBeVisible();
       await expect(providerRow).toContainText(/connected/i);
     });
 
@@ -105,9 +107,9 @@ test.describe('@smoke discovery', () => {
       const discoveryName = `smoke-discovery-${Date.now()}`;
       discoveryUuid = await discoveryPage.createDiscovery(
         discoveryName,
-        env.discoveryProviderName!,
+        env.smoke.discoveryProviderName!,
         'IP-Hostname',
-        env.discoveryTarget!
+        env.smoke.discoveryTarget!
       );
     });
 

--- a/czertainly-e2e/tests/smoke/smokeData.ts
+++ b/czertainly-e2e/tests/smoke/smokeData.ts
@@ -16,8 +16,9 @@ export const sidebarItems: readonly SidebarItem[] = [
         role: 'button',
         name: 'Dashboard',
         children: [
-            { role: 'link', name: 'Certificates Dashboard', urlHint: /\/dashboard\/certificates/i },
-            { role: 'link', name: 'Secrets Dashboard', urlHint: /\/dashboard\/secrets/i },
+            { role: 'link', name: 'Certificates', urlHint: /\/dashboard\/certificates/i },
+            { role: 'link', name: 'Secrets', urlHint: /\/dashboard\/secrets/i },
+            { role: 'link', name: 'Signing Records', urlHint: /\/dashboard\/signing-records/i },
         ],
     },
     { role: 'link', name: 'Certificates', urlHint: /\/certificates/i },
@@ -26,6 +27,7 @@ export const sidebarItems: readonly SidebarItem[] = [
     { role: 'link', name: 'Connectors', urlHint: /connectors/i },
     { role: 'link', name: 'Secrets', urlHint: /\/secrets/i },
     { role: 'link', name: 'CBOMs', urlHint: /\/cboms/i },
+    { role: 'link', name: 'Signing Records', urlHint: /\/signingrecords/i },
     {
         role: 'button',
         name: 'Access Control',
@@ -43,6 +45,7 @@ export const sidebarItems: readonly SidebarItem[] = [
             { role: 'link', name: 'Compliance Profiles', urlHint: /complianceprofiles/i },
             { role: 'link', name: 'Notification Profiles', urlHint: /notificationprofiles/i },
             { role: 'link', name: 'Vault Profiles', urlHint: /vaultprofiles/i },
+            { role: 'link', name: 'Signing Profiles', urlHint: /signingprofiles/i },
         ],
     },
     {
@@ -66,6 +69,7 @@ export const sidebarItems: readonly SidebarItem[] = [
             { role: 'link', name: 'ACME Profiles', urlHint: /acmeprofiles/i },
             { role: 'link', name: 'CMP Profiles', urlHint: /cmpprofiles/i },
             { role: 'link', name: 'SCEP Profiles', urlHint: /scepprofiles/i },
+            { role: 'link', name: 'TSP Profiles', urlHint: /tspprofiles/i },
         ],
     },
     {
@@ -88,6 +92,7 @@ export const sidebarItems: readonly SidebarItem[] = [
             { role: 'link', name: 'Logging', urlHint: /loggingsettings/i },
             { role: 'link', name: 'Authentication', urlHint: /authenticationsettings/i },
             { role: 'link', name: 'Custom OIDs', urlHint: /custom-oids/i },
+            { role: 'link', name: 'Time Quality', urlHint: /timequalityconfigurations/i },
         ],
     },
     { role: 'link', name: 'Audit Logs', urlHint: /auditlogs/i },

--- a/czertainly-e2e/utils/connectorUtils.ts
+++ b/czertainly-e2e/utils/connectorUtils.ts
@@ -1,9 +1,22 @@
+/**
+ * connectorUtils — wrapper around CZERTAINLY Core /api/v1/connectors and /api/v2/connectors.
+ *
+ * Provides:
+ *  - getAllConnectors / findConnectorByName — read helpers
+ *  - registerConnector — probe + register (auto-detects v1/v2 from connector's own advertisement)
+ *  - ensureConnectorRegistered — idempotent: returns existing or registers + approves;
+ *    reports whether THIS call did the registration (so teardown only deletes its own)
+ *  - deleteConnector — best-effort delete
+ *  - approveConnector / checkConnectorHealth — small helpers
+ */
+
 import { APIRequestContext } from '@playwright/test';
 import { Logger } from './Logger';
 
 const logger = new Logger('ConnectorUtils');
 
 const CONNECTORS_API = '/api/v1/connectors';
+const CONNECTORS_API_V2 = '/api/v2/connectors';
 
 export interface ConnectorDto {
     uuid: string;
@@ -39,6 +52,87 @@ export async function findConnectorByName(
         throw new Error(`Connector "${name}" not found. Available: ${available}`);
     }
     return found;
+}
+
+export async function registerConnector(
+    request: APIRequestContext,
+    options: { name: string; url: string; authType?: string },
+): Promise<ConnectorDto> {
+    const authType = options.authType ?? 'none';
+    logger.info(`Probing connector "${options.name}" at ${options.url}`);
+
+    // Step 1: probe — Core validates the URL and discovers what version(s) the connector advertises.
+    // The UI sends this before POST /connectors; skipping it makes the register call return 500.
+    const probeResp = await request.post(`${CONNECTORS_API_V2}/connect`, {
+        data: { url: options.url, authType, authAttributes: [] },
+    });
+    if (!probeResp.ok()) {
+        const error = await probeResp.text();
+        throw new Error(`Connector probe failed for "${options.name}" at ${options.url}: ${probeResp.status()} - ${error}`);
+    }
+    const advertised = await probeResp.json() as Array<{ version: string }>;
+    if (!Array.isArray(advertised) || advertised.length === 0 || !advertised[0].version) {
+        throw new Error(`Connector "${options.name}" probe returned no version info`);
+    }
+    const version = advertised[0].version;
+
+    // Step 2: register using the version advertised by the connector itself.
+    logger.info(`Registering connector "${options.name}" (version: ${version})`);
+    const response = await request.post(CONNECTORS_API_V2, {
+        data: {
+            name: options.name,
+            url: options.url,
+            authType,
+            authAttributes: [],
+            customAttributes: [],
+            version,
+        },
+    });
+    if (!response.ok()) {
+        const error = await response.text();
+        logger.error(`Failed to register connector "${options.name}": ${response.status()} - ${error}`);
+        throw new Error(`Failed to register connector "${options.name}": ${response.status()} - ${error}`);
+    }
+    return await response.json() as ConnectorDto;
+}
+
+export interface EnsureConnectorResult {
+    connector: ConnectorDto;
+    /** True if THIS run registered the connector; false if it pre-existed. */
+    registered: boolean;
+}
+
+export async function ensureConnectorRegistered(
+    request: APIRequestContext,
+    options: { name: string; url: string },
+): Promise<EnsureConnectorResult> {
+    const connectors = await getAllConnectors(request);
+    const existing = connectors.find(c => c.name === options.name);
+    if (existing) {
+        logger.info(`Connector "${options.name}" already registered (uuid: ${existing.uuid})`);
+        return { connector: existing, registered: false };
+    }
+    logger.info(`Connector "${options.name}" not registered — registering`);
+    const registered = await registerConnector(request, options);
+    // Approve only if Core left the connector in WAITING_FOR_APPROVAL.
+    // Some Core versions auto-connect on register; approving a Connected one returns 422.
+    if (registered.status === 'waitingForApproval' || registered.status === 'WAITING_FOR_APPROVAL') {
+        await approveConnector(request, registered.uuid);
+    }
+    return { connector: registered, registered: true };
+}
+
+export async function deleteConnector(
+    request: APIRequestContext,
+    uuid: string,
+): Promise<void> {
+    logger.info(`Deleting connector: ${uuid}`);
+    const resp = await request.delete(`${CONNECTORS_API}/${uuid}`);
+    if (!resp.ok() && resp.status() !== 204 && resp.status() !== 404) {
+        const error = await resp.text();
+        logger.error(`Failed to delete connector ${uuid}: ${resp.status()} - ${error}`);
+        throw new Error(`Failed to delete connector: ${resp.status()} - ${error}`);
+    }
 }
 
 export async function approveConnector(

--- a/czertainly-e2e/utils/env.ts
+++ b/czertainly-e2e/utils/env.ts
@@ -1,25 +1,49 @@
+/**
+ * env.ts — single source of truth for test configuration.
+ *
+ * WHAT: loads `.env` via dotenv, builds a typed `TestEnv` object, validates it.
+ * WHY: tests stay decoupled from raw `process.env` strings and get fail-fast errors
+ *      when something is missing, instead of mysterious failures deep in a test.
+ * HOW: `loadEnv()` reads env vars, applies defaults where it makes sense, calls
+ *      `required()` for vars every test needs (baseUrl, credentials). Smoke-only
+ *      vars live in nested `env.smoke` and are validated as a group: every smoke
+ *      var must be present, otherwise loadEnv throws and the whole suite fails red.
+ *
+ *      `SMOKE_PERSIST=true` makes globalSetup reuse a previously-written state
+ *      file (no re-provisioning) and globalTeardown preserve it. Strict env
+ *      validation still applies in both modes.
+ */
+
 import * as dotenv from 'dotenv';
-dotenv.config();
+dotenv.config(); // reads .env in current dir, copies KEY=VALUE into process.env
 
 type AuthMode = 'local' | 'oidc';
 
 export type TestEnv = {
   baseUrl: string;
-  authMode: AuthMode;
+  authMode: AuthMode; // default 'local'
   username: string;
   password: string;
-  clientSecret?: string;
-  authClientId: string;
-  authRealm: string;
+  clientSecret?: string; // needed only for oidc
+  authClientId: string; // default 'ilm'
+  authRealm: string; // default 'ILM'
   authBaseUrl?: string;
   localAuthProviderName: string;
+  smokePersist: boolean;  // SMOKE_PERSIST=true → reuse state between runs, skip teardown
+  smoke: SmokeEnv;
+};
+
+export type SmokeEnv = {
+  // SMK-003 — Network Discovery
   discoveryProviderName?: string;
   discoveryProviderUrl?: string;
   discoveryTarget?: string;
 
-  // SMK-004 — Issue Certificate (per-run creation via API in globalSetup)
-  ejbcaConnectorName: string;
-  credentialConnectorName: string;
+  // SMK-004 — Issue Certificate (setup config + per-run data)
+  ejbcaConnectorName?: string;        // name under which to register the EJBCA connector in Core
+  ejbcaConnectorUrl?: string;         // cluster-internal service URL of the EJBCA connector pod
+  credentialConnectorName?: string;   // name under which to register the credential-provider connector in Core
+  credentialConnectorUrl?: string;    // cluster-internal service URL of the credential-provider connector pod
   ejbcaWsUrl?: string;
   ejbcaP12Base64?: string;
   ejbcaP12Password?: string;
@@ -42,7 +66,7 @@ export function loadEnv(): TestEnv {
     throw new Error(`AUTH_MODE must be either 'local' or 'oidc', but got: ${process.env.AUTH_MODE}`);
   }
 
-  return {
+  const env: TestEnv = { // build up the object
     baseUrl: required('BASE_URL'),
     authMode,
     username: required('SMOKE_USERNAME'),
@@ -52,18 +76,48 @@ export function loadEnv(): TestEnv {
     authRealm: process.env.AUTH_REALM || 'ILM',
     authBaseUrl: process.env.AUTH_BASE_URL, // Defaults to baseUrl/kc if not set
     localAuthProviderName: required('LOCAL_AUTH_PROVIDER_NAME'),
-    discoveryProviderUrl: process.env.DISCOVERY_PROVIDER_URL,
-    discoveryProviderName: process.env.DISCOVERY_PROVIDER_NAME,
-    discoveryTarget: process.env.DISCOVERY_TARGET,
+    smokePersist: process.env.SMOKE_PERSIST === 'true',
+    smoke: {
+      discoveryProviderName: process.env.DISCOVERY_PROVIDER_NAME,
+      discoveryProviderUrl: process.env.DISCOVERY_PROVIDER_URL,
+      discoveryTarget: process.env.DISCOVERY_TARGET,
 
-    // SMK-004 — Issue Certificate (per-run creation via API in globalSetup)
-    ejbcaConnectorName: process.env.EJBCA_CONNECTOR_NAME || 'EJBCA-NG-Connector',
-    credentialConnectorName: process.env.CREDENTIAL_CONNECTOR_NAME || 'Common-Credential-Connector',
-    ejbcaWsUrl: process.env.EJBCA_WS_URL,
-    ejbcaP12Base64: process.env.EJBCA_P12_BASE64,
-    ejbcaP12Password: process.env.EJBCA_P12_PASSWORD,
-    ejbcaCaName: process.env.EJBCA_CA_NAME,
-    ejbcaEndEntityProfile: process.env.EJBCA_END_ENTITY_PROFILE,
-    ejbcaCertificateProfile: process.env.EJBCA_CERTIFICATE_PROFILE,
+      ejbcaConnectorName: process.env.EJBCA_CONNECTOR_NAME,
+      ejbcaConnectorUrl: process.env.EJBCA_CONNECTOR_URL,
+      credentialConnectorName: process.env.CREDENTIAL_CONNECTOR_NAME,
+      credentialConnectorUrl: process.env.CREDENTIAL_CONNECTOR_URL,
+      ejbcaWsUrl: process.env.EJBCA_WS_URL,
+      ejbcaP12Base64: process.env.EJBCA_P12_BASE64,
+      ejbcaP12Password: process.env.EJBCA_P12_PASSWORD,
+      ejbcaCaName: process.env.EJBCA_CA_NAME,
+      ejbcaEndEntityProfile: process.env.EJBCA_END_ENTITY_PROFILE,
+      ejbcaCertificateProfile: process.env.EJBCA_CERTIFICATE_PROFILE,
+    },
   };
+
+  // Strict smoke validation — every smoke env var must be present, otherwise the
+  // whole suite fails red. There's no bypass; if you don't have full secrets, get
+  // them from the team. SMOKE_PERSIST only affects state reuse, not validation.
+  const missing = getMissingSmokeVars(env);
+  if (missing.length > 0) {
+    throw new Error(`Smoke env incomplete: ${missing.join(', ')}.`);
+  }
+
+  return env;
+}
+
+/**
+ * Returns names of SMK-required env vars that are currently missing.
+ * Called by loadEnv() itself to enforce strict validation — if anything's missing,
+ * loadEnv throws and the whole suite fails red.
+ *
+ * Field names in SmokeEnv use camelCase and are converted to SCREAMING_SNAKE_CASE
+ * to match the .env variable names (e.g. ejbcaWsUrl → EJBCA_WS_URL).
+ */
+export function getMissingSmokeVars(env: TestEnv): string[] {
+  const toEnvVarName = (key: string): string =>
+    key.split(/(?=[A-Z])/).join('_').toUpperCase();
+  return Object.entries(env.smoke)
+    .filter(([, v]) => !v)
+    .map(([k]) => toEnvVarName(k));
 }

--- a/czertainly-e2e/utils/smokeState.ts
+++ b/czertainly-e2e/utils/smokeState.ts
@@ -1,9 +1,12 @@
 /**
  * smokeState — file-based state sharing between Playwright globalSetup and globalTeardown.
  *
- * globalSetup writes the SmokeState (UUIDs of created Credential / Authority / RA Profile)
- * to .smoke-state.json. globalTeardown reads it to know what to delete in reverse order.
- * The file is gitignored.
+ * globalSetup writes the SmokeState to .smoke-state.json (gitignored). globalTeardown
+ * reads it to know what to delete in reverse dependency order.
+ *
+ * State is all-or-nothing: globalSetup either writes the full SmokeState (all PKI
+ * fields + connector UUIDs together) or doesn't write anything. Tests can rely on
+ * any field being present when `readSmokeState()` returns non-null.
  *
  * Why a file: globalSetup and globalTeardown are separate function invocations in
  * Playwright's lifecycle — in-memory state between them is not reliable.
@@ -19,6 +22,10 @@ const logger = new Logger('SmokeState');
 const STATE_FILE = path.resolve(__dirname, '..', '.smoke-state.json');
 
 export interface SmokeState {
+  /** UUIDs of connectors registered by THIS run — globalTeardown deletes them. */
+  registeredConnectorUuids: string[];
+
+  // SMK-004 PKI chain — always written together with the rest of the state.
   credentialUuid: string;
   credentialName: string;
   authorityUuid: string;


### PR DESCRIPTION
## Summary

- **Sidebar fix**: FE renamed Dashboard children (e.g. Certificates Dashboard → Certificates) and added Signing Records / Signing Profiles / TSP Profiles / Time Quality, creating duplicate names with top-level items. `Navigation.openViaSidebar` and SMK-001's sidebar visibility loop are now structurally scoped to direct-child `<a>`/`<button>` of the main `<ul>` so nested submenu items don't collide.
- **Auto-provision connectors**: `globalSetup` registers EJBCA, Common-Credential, and Network Discovery connectors (idempotent — finds existing or creates), then provisions per-run PKI chain. `globalTeardown` deletes only connectors THIS run registered, so shared environments aren't disrupted.
- **Single source of truth for smoke config** in `env.ts`: `SmokeEnv` group + strict validation in `loadEnv()` (throws on any missing smoke var). `SMOKE_PERSIST=true` skips re-provisioning + teardown for fast local iteration.
- **TablePage.applyFilter()**: encapsulates the new Connector Filter UI (Property → Name → contains → value) so spec files stay POM-clean.
- **LoginPage** uses exact `role+name` match to disambiguate envs with multiple "Internal*" identity providers.

## Test plan

- [x] SMK-001 auth — passes on develop-02
- [x] SMK-002 navigation — passes (sidebar duplicate-name fix verified)
- [x] SMK-003 discovery — passes (new Connector Filter UI working)
- [x] SMK-004 cert issuance — passes (after Core fix `interfaces#744`)
- [x] All 4 tests in 50s
- [x] Strict env validation: removing any smoke var → loadEnv throws → all tests red with clear message
- [x] `SMOKE_PERSIST=true` reuse-mode verified locally