### PR TITLE
fix(smoke): adapt SMK-004 to certificate request-type radios

### DIFF
--- a/czertainly-e2e/pages/CertificatePage.ts
+++ b/czertainly-e2e/pages/CertificatePage.ts
@@ -27,6 +27,7 @@ export class CertificatePage {
     readonly addCertificateButton: Locator;
 
     // Issue page (separate URL: /certificates/add, not a modal)
+    readonly requestTypeIssue: Locator;
     readonly raProfileTrigger: Locator;
     readonly keySourceTrigger: Locator;
     readonly csrTextarea: Locator;
@@ -42,8 +43,9 @@ export class CertificatePage {
         this.main = page.locator('main');
         this.addCertificateButton = this.main.getByTestId('add-certificate-button');
 
+        this.requestTypeIssue = this.main.getByTestId('requestType-issue');
         this.raProfileTrigger = this.main.getByTestId('select-raProfile-trigger');
-        this.keySourceTrigger = this.main.getByTestId('select-uploadCsr-trigger');
+        this.keySourceTrigger = this.main.getByTestId('keySource-trigger');
         this.csrTextarea = this.main.locator('#__fileUpload__fileContent');
         this.submitButton = this.main.getByTestId('progress-button');
 
@@ -65,6 +67,11 @@ export class CertificatePage {
         logger.info('Navigating to Issue Certificate page');
         await this.addCertificateButton.click();
         await expect(this.page).toHaveURL(/\/certificates\/add/);
+    }
+
+    async selectRequestTypeIssue(): Promise<void> {
+        logger.info('Selecting Request Type: Issue now');
+        await this.requestTypeIssue.click();
     }
 
     async selectRaProfile(raProfileName: string): Promise<void> {

--- a/czertainly-e2e/tests/smoke/certificate.smoke.spec.ts
+++ b/czertainly-e2e/tests/smoke/certificate.smoke.spec.ts
@@ -69,6 +69,7 @@ test.describe('@smoke certificate', () => {
 
         await test.step('Issue certificate via UI', async () => {
             await certPage.openIssuePage();
+            await certPage.selectRequestTypeIssue();
             await certPage.selectRaProfile(state.raProfileName);
             await certPage.selectKeySourceExternal();
             await certPage.pasteCsr(csr);


### PR DESCRIPTION
## Problem

SMK-004 (`certificate.smoke.spec.ts`) started failing with a 15s timeout on `select-uploadCsr-trigger` when selecting Key Source.

Root cause is FE PR #1862 *"UI for certificate pre-registration and issue-from-registered"*, which:
1. Added **Request Type** radio buttons (`requestType-issue` / `requestType-register`), with `issue` checked by default.
2. Renamed the **Key Source** select testid from `select-uploadCsr-trigger` to `keySource-trigger` (the component now uses an explicit `dataTestId="keySource"` instead of deriving it from `id`).

## Fix

- Point `keySourceTrigger` at the new `keySource-trigger` testid.
- Add `requestTypeIssue` locator + `selectRequestTypeIssue()` method.
- Select **Issue now** first in the UI flow, before RA Profile, so the request type is fixed before the dependent form fields render (the FE uses `useWatch` on `requestType` to toggle field visibility). This also documents the test's intent rather than silently relying on the current default.

## Verification

`npx playwright test tests/smoke/certificate.smoke.spec.ts` → **1 passed (17.6s)** — full flow: provision PKI chain → issue cert via UI → reach `issued` state → assert all detail tabs → clean teardown.