### PR TITLE
feat(smoke): SMK-007 upload-cert + SMK-005 recon (skipped)

### DIFF
--- a/czertainly-e2e/.env.example
+++ b/czertainly-e2e/.env.example
@@ -54,3 +54,12 @@ EJBCA_CERTIFICATE_PROFILE=
 # Generate base64: base64 -i admin.p12 | tr -d '\n'
 EJBCA_P12_BASE64=
 EJBCA_P12_PASSWORD=
+
+# === SMK-005: ACME certificate issuance (in development) ===
+# Namespace where the smoke test creates Issuer / Certificate / Secret
+SMOKE_TESTS_NAMESPACE=smoke-tests
+
+# === k8s local access (optional) ===
+# Path to kubeconfig file for local runs. Leave empty in Testkube — pod uses
+# its own ServiceAccount token automatically.
+KUBECONFIG_PATH=

--- a/czertainly-e2e/.env.example
+++ b/czertainly-e2e/.env.example
@@ -57,7 +57,7 @@ EJBCA_P12_PASSWORD=
 
 # === SMK-005: ACME certificate issuance (in development) ===
 # Namespace where the smoke test creates Issuer / Certificate / Secret
-SMOKE_TESTS_NAMESPACE=smoke-tests
+SMOKE_TESTS_NAMESPACE=testkube-runner
 
 # === k8s local access (optional) ===
 # Path to kubeconfig file for local runs. Leave empty in Testkube — pod uses

--- a/czertainly-e2e/package-lock.json
+++ b/czertainly-e2e/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@kubernetes/client-node": "^1.4.0",
         "dotenv": "^17.2.3"
       },
       "devDependencies": {
@@ -17,6 +18,69 @@
         "@types/node-forge": "^1.3.14",
         "node-forge": "^1.4.0"
       }
+    },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@kubernetes/client-node": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-1.4.0.tgz",
+      "integrity": "sha512-Zge3YvF7DJi264dU1b3wb/GmzR99JhUpqTvp+VGHfwZT+g7EOOYNScDJNZwXy9cszyIGPIs0VHr+kk8e95qqrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/js-yaml": "^4.0.1",
+        "@types/node": "^24.0.0",
+        "@types/node-fetch": "^2.6.13",
+        "@types/stream-buffers": "^3.0.3",
+        "form-data": "^4.0.0",
+        "hpagent": "^1.2.0",
+        "isomorphic-ws": "^5.0.0",
+        "js-yaml": "^4.1.0",
+        "jsonpath-plus": "^10.3.0",
+        "node-fetch": "^2.7.0",
+        "openid-client": "^6.1.3",
+        "rfc4648": "^1.3.0",
+        "socks-proxy-agent": "^8.0.4",
+        "stream-buffers": "^3.0.2",
+        "tar-fs": "^3.0.9",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@kubernetes/client-node/node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@kubernetes/client-node/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
     },
     "node_modules/@playwright/test": {
       "version": "1.58.0",
@@ -34,14 +98,29 @@
         "node": ">=18"
       }
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "25.1.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.1.0.tgz",
       "integrity": "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
       }
     },
     "node_modules/@types/node-forge": {
@@ -54,6 +133,181 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/stream-buffers": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/stream-buffers/-/stream-buffers-3.0.8.tgz",
+      "integrity": "sha512-J+7VaHKNvlNPJPEJXX/fKa9DZtR/xPMwuIbe+yNOwp1YB+ApUOBv2aUpEoBJEi8nJgbgs1x8e73ttg0r1rSUdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.8.0.tgz",
+      "integrity": "sha512-fM+MhCvdQhZ7NV6S95a07gPSqjIYKn6mFaXfx266wN3ajZGl/+1AzH+ubkXQ0fFZvOe2nk9VHkzdYkQE5zMV3Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.28.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
+      "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.5.2.tgz",
+      "integrity": "sha512-L13PCJzKG8RGvx8V1/DdMi12ERhC3tprr7/8a94BxpmnRsFqxh5XZNdhtMxu5HPkRshYOOWRGY8lDP7ZhpG9Cg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/dotenv": {
       "version": "17.2.3",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
@@ -64,6 +318,105 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fsevents": {
@@ -81,6 +434,245 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hpagent": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/isomorphic-ws": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsep": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
+    "node_modules/jsonpath-plus": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.4.0.tgz",
+      "integrity": "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-forge": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
@@ -89,6 +681,37 @@
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/openid-client": {
+      "version": "6.8.4",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.4.tgz",
+      "integrity": "sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^6.2.2",
+        "oauth4webapi": "^3.8.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/playwright": {
@@ -123,12 +746,179 @@
         "node": ">=18"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rfc4648": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.5.4.tgz",
+      "integrity": "sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg==",
+      "license": "MIT"
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/stream-buffers": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-3.0.3.tgz",
+      "integrity": "sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.3.tgz",
+      "integrity": "sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/czertainly-e2e/package.json
+++ b/czertainly-e2e/package.json
@@ -16,6 +16,7 @@
     "node-forge": "^1.4.0"
   },
   "dependencies": {
+    "@kubernetes/client-node": "^1.4.0",
     "dotenv": "^17.2.3"
   }
 }

--- a/czertainly-e2e/pages/CertificatePage.ts
+++ b/czertainly-e2e/pages/CertificatePage.ts
@@ -26,6 +26,17 @@ export class CertificatePage {
     readonly main: Locator;
     readonly addCertificateButton: Locator;
 
+    // Upload Certificate
+    readonly uploadButton: Locator;
+    readonly uploadModal: Locator;
+    readonly uploadFileContentTextarea: Locator;
+    readonly uploadSubmitButton: Locator;
+
+    // Delete certificate from Details page
+    readonly deleteButton: Locator;
+    readonly deleteConfirmDialog: Locator;
+    readonly deleteConfirmButton: Locator;
+
     // Issue page (separate URL: /certificates/add, not a modal)
     readonly requestTypeIssue: Locator;
     readonly raProfileTrigger: Locator;
@@ -33,7 +44,7 @@ export class CertificatePage {
     readonly csrTextarea: Locator;
     readonly submitButton: Locator;
 
-    // Detail page
+    // Details page
     readonly tablist: Locator;
 
     constructor(page: Page) {
@@ -42,6 +53,16 @@ export class CertificatePage {
 
         this.main = page.locator('main');
         this.addCertificateButton = this.main.getByTestId('add-certificate-button');
+
+        this.uploadButton = this.main.getByTestId('upload-button');
+        this.uploadModal = page.getByRole('dialog').filter({ hasText: 'Upload Certificate' });
+        this.uploadFileContentTextarea = this.uploadModal.locator('#__fileUpload__fileContent');
+        this.uploadSubmitButton = this.uploadModal.getByTestId('progress-button');
+
+        this.deleteButton = this.main.getByTestId('trash-button');
+        this.deleteConfirmDialog = page.getByRole('dialog').filter({ hasText: 'Delete Certificate' });
+        this.deleteConfirmButton = this.deleteConfirmDialog.getByRole('button', { name: 'Delete', exact: true });
+
 
         this.requestTypeIssue = this.main.getByTestId('requestType-issue');
         this.raProfileTrigger = this.main.getByTestId('select-raProfile-trigger');
@@ -67,6 +88,31 @@ export class CertificatePage {
         logger.info('Navigating to Issue Certificate page');
         await this.addCertificateButton.click();
         await expect(this.page).toHaveURL(/\/certificates\/add/);
+    }
+
+    async openUploadModal(): Promise<void> {
+        logger.info('Opening Upload Certificate modal');
+        await this.uploadButton.click();
+        await expect(this.uploadModal).toBeVisible();
+    }
+
+    async pasteCertificatePem(pem: string): Promise<void> {
+        logger.info('Pasting certificate PEM into textarea');
+        await this.uploadFileContentTextarea.fill(pem);
+    }
+
+    async submitUpload(): Promise<void> {
+        logger.info('Submitting upload');
+        await this.uploadSubmitButton.click();
+        await expect(this.uploadModal).not.toBeVisible();
+    }
+
+    async deleteFromDetail(): Promise<void> {
+        logger.info('Deleting certificate from details page');
+        await this.deleteButton.click();
+        await expect(this.deleteConfirmDialog).toBeVisible();
+        await this.deleteConfirmButton.click();
+        await expect(this.deleteConfirmDialog).not.toBeVisible();
     }
 
     async selectRequestTypeIssue(): Promise<void> {

--- a/czertainly-e2e/tests/smoke/acme-cert.smoke.spec.ts
+++ b/czertainly-e2e/tests/smoke/acme-cert.smoke.spec.ts
@@ -1,0 +1,37 @@
+/**
+ *
+ * WHAT: SMK-005 test to issue a certificate through ACME protocol, now just to explore the k8s cluster on what have been already installed (cert-manager, ingress-nginx) and what permissions we have
+ * 
+ * WHY: because we don't know concrete versions, names, and namespaces in the cluster 
+ * 
+ * HOW: we send read-only requests via k8sClient to get:
+ *      1. list of namespaces
+ *      2. pods in cert-manager namespace
+ *      3. ingress classes
+ *      4. CRDs with cert-manager.io suffix
+ *      5. SelfSubjectAccessReview for critical operations (create Issuer/Certificate/Secret/Ingress)
+ *      6. we print everything to the logs via Logger
+ */
+
+import { test } from '../../fixtures/testFixtures';
+import {
+    getCoreApi,
+    getCustomObjectsApi,
+    getNetworkingApi,
+    getAuthorizationApi,
+} from '../../utils/k8sClient';
+import { Logger } from '../../utils/Logger';
+
+const logger = new Logger('AcmeSmokeTest');
+
+test.describe('@smoke acme', () => {
+    test('SMK-005: reconnaissance — what is available in the cluster', async () => {
+        await test.step('List all namespaces', async () => {
+            const coreApi = getCoreApi();
+            const nsList = await coreApi.listNamespace();
+            const names = nsList.items.map(ns => ns.metadata?.name);
+            logger.info(`Found ${names.length} namespaces: ${names.join(', ')}`);
+        });
+
+    });
+});

--- a/czertainly-e2e/tests/smoke/acme-cert.smoke.spec.ts
+++ b/czertainly-e2e/tests/smoke/acme-cert.smoke.spec.ts
@@ -24,8 +24,10 @@ import { Logger } from '../../utils/Logger';
 
 const logger = new Logger('AcmeSmokeTest');
 
+// TODO: enable when Testkube ServiceAccount has RBAC to create Issuer/Certificate 
+// in `testkube-runner` namespace.
 test.describe('@smoke acme', () => {
-    test('SMK-005: reconnaissance — what is available in the cluster', async ({ env }) => {
+    test.skip('SMK-005: reconnaissance — what is available in the cluster', async ({ env }) => {
         await test.step('Check permissions via SelfSubjectAccessReview', async () => {
             const authApi = getAuthorizationApi();
 

--- a/czertainly-e2e/tests/smoke/acme-cert.smoke.spec.ts
+++ b/czertainly-e2e/tests/smoke/acme-cert.smoke.spec.ts
@@ -25,12 +25,54 @@ import { Logger } from '../../utils/Logger';
 const logger = new Logger('AcmeSmokeTest');
 
 test.describe('@smoke acme', () => {
-    test('SMK-005: reconnaissance — what is available in the cluster', async () => {
-        await test.step('List all namespaces', async () => {
-            const coreApi = getCoreApi();
-            const nsList = await coreApi.listNamespace();
-            const names = nsList.items.map(ns => ns.metadata?.name);
-            logger.info(`Found ${names.length} namespaces: ${names.join(', ')}`);
+    test('SMK-005: reconnaissance — what is available in the cluster', async ({ env }) => {
+        await test.step('Check permissions via SelfSubjectAccessReview', async () => {
+            const authApi = getAuthorizationApi();
+
+            const canI = async (
+                verb: string,
+                resource: string,
+                group: string,
+                namespace?: string,
+            ): Promise<boolean> => {
+                const review = await authApi.createSelfSubjectAccessReview({
+                    body: {
+                        spec: {
+                            resourceAttributes: { verb, resource, group, namespace },
+                        },
+                    },
+                });
+                return review.status?.allowed === true;
+            };
+
+            const smokeNs = env.smoke.namespace!;  // guaranteed present by strict env validation
+
+            const checks: Array<{ verb: string; resource: string; group: string; namespace?: string }> = [
+                // Cluster-scope — what we can do at the cluster level
+                { verb: 'list', resource: 'namespaces', group: '' },
+                { verb: 'create', resource: 'clusterissuers', group: 'cert-manager.io' },
+                { verb: 'list', resource: 'clusterissuers', group: 'cert-manager.io' },
+                { verb: 'list', resource: 'ingressclasses', group: 'networking.k8s.io' },
+                { verb: 'list', resource: 'customresourcedefinitions', group: 'apiextensions.k8s.io' },
+
+                // Namespaced in our smoke namespace — what we can read/write at our place
+                { verb: 'create', resource: 'issuers', group: 'cert-manager.io', namespace: smokeNs },
+                { verb: 'create', resource: 'certificates', group: 'cert-manager.io', namespace: smokeNs },
+                { verb: 'create', resource: 'secrets', group: '', namespace: smokeNs },
+                { verb: 'get', resource: 'secrets', group: '', namespace: smokeNs },
+                { verb: 'create', resource: 'ingresses', group: 'networking.k8s.io', namespace: smokeNs },
+
+                // Namespaced в cert-manager — can we read at least what's installed there
+                { verb: 'list', resource: 'pods', group: '', namespace: 'cert-manager' },
+            ];
+
+            for (const check of checks) {
+                const allowed = await canI(check.verb, check.resource, check.group, check.namespace);
+                const scope = check.namespace ? `ns:${check.namespace}` : 'cluster-scope';
+                const groupLabel = check.group || 'core';
+                const verdict = allowed ? 'ALLOWED' : 'DENIED';
+                logger.info(`${verdict} — ${check.verb} ${check.resource} (${groupLabel}) [${scope}]`);
+            }
         });
 
     });

--- a/czertainly-e2e/tests/smoke/upload-cert.smoke.spec.ts
+++ b/czertainly-e2e/tests/smoke/upload-cert.smoke.spec.ts
@@ -1,0 +1,121 @@
+/**
+ *
+ * WHAT: SMK-007 test covers certificate upload without issuance + certificate delete (single delete from the Certificate Details page + bulk delete from the list)
+ * WHY: this is a separate flow from SMK-004 (we issue a certificate through RA profile there), and here we work with prepared certificates + batch delete in the risk zone (broke often in the past -> need to check for regression)
+ * 
+ * HOW: test flow:
+ *      1. Login → Certificates list
+ *      2. Upload 1 cert via UI-modal (UI-path upload validation) (note: we'll be using self-signed certs and generate them via node-forge, so no external fixtures)
+ *      3. Upload 2 more certs via API (faster, hermetic)
+ *      4. Filter by our unique CN-prefix (don't touch someone else inventory)
+ *      5. Single delete via detail page → verify 2 remain
+ *      6. Batch delete remaining via list toolbar → verify clean
+ *      7. afterEach — API cleanup if test fails ahead of batch delete
+ */
+
+import { test, expect, loginAsSmokeUser, getAuthenticatedApiContext } from '../../fixtures/testFixtures';
+import { CertificatePage } from '../../pages/CertificatePage';
+import { TablePage } from '../../pages/TablePage';
+import { Logger } from '../../utils/Logger';
+import {
+    generateSelfSignedCert,
+    uploadCertificate,
+    findCertificateByFingerprint,
+    deleteCertificate,
+} from '../../utils/certificateUtils';
+
+
+const logger = new Logger('UploadCertSmokeTest');
+
+test.describe('@smoke upload-cert', () => {
+    // Track fingerprints of uploaded certs — for afterEach cleanup
+    const uploadedFingerprints: string[] = [];
+
+    test.afterEach(async ({ request, env }) => {
+        if (uploadedFingerprints.length === 0) return;
+
+        const api = await getAuthenticatedApiContext(request, env);
+        try {
+            for (const fingerprint of uploadedFingerprints) {
+                try {
+                    const found = await findCertificateByFingerprint(api, fingerprint);
+                    if (found) {
+                        await deleteCertificate(api, found.uuid);
+                        logger.info(`Cleaned up leftover cert: ${fingerprint} → ${found.uuid}`);
+                    }
+                } catch (e) {
+                    logger.warn(`Cleanup failed for fingerprint ${fingerprint}: ${e}`);
+                }
+            }
+        } finally {
+            await api.dispose();
+            uploadedFingerprints.length = 0;  // Reset for potential next run
+        }
+    });
+
+    test('SMK-007: upload certificate and delete (single + batch)', async ({ page, request, env }) => {
+        const certPage = new CertificatePage(page);
+        const tablePage = new TablePage(page);
+        const cnPrefix = `smoke-upload-${Date.now()}`;
+
+        // 1. Generate 3 self-signed certs with unique CN sharing our timestamp prefix
+        const cert1 = generateSelfSignedCert(`${cnPrefix}-1.example.com`);
+        const cert2 = generateSelfSignedCert(`${cnPrefix}-2.example.com`);
+        const cert3 = generateSelfSignedCert(`${cnPrefix}-3.example.com`);
+
+        await loginAsSmokeUser(page, env);
+
+        await test.step('Upload cert #1 via UI modal', async () => {
+            await certPage.goToList();
+            await certPage.openUploadModal();
+            await certPage.pasteCertificatePem(cert1.pem);
+            await certPage.submitUpload();
+            uploadedFingerprints.push(cert1.fingerprint);
+            logger.info(`Uploaded via UI: ${cert1.fingerprint}`);
+        });
+
+        await test.step('Upload certs #2 and #3 via API', async () => {
+            const api = await getAuthenticatedApiContext(request, env);
+            try {
+                await uploadCertificate(api, cert2.pem);
+                uploadedFingerprints.push(cert2.fingerprint);
+                await uploadCertificate(api, cert3.pem);
+                uploadedFingerprints.push(cert3.fingerprint);
+                logger.info(`Uploaded via API: ${cert2.fingerprint}, ${cert3.fingerprint}`);
+            } finally {
+                await api.dispose();
+            }
+        });
+
+        await test.step('Filter list by CN prefix and verify 3 certs visible', async () => {
+            await page.reload();  // pick up newly uploaded certs — list doesn't auto-refresh
+            await tablePage.applyFilter({
+                group: 'Property',
+                field: 'Common Name',
+                condition: 'contains',
+                value: cnPrefix,
+            });
+            await expect(tablePage.rows).toHaveCount(3, { timeout: 15000 });
+        });
+
+        await test.step('Delete cert #1 via detail page → verify 2 remain', async () => {
+            // Click first cert's CN link → navigate to detail
+            const firstRowLink = tablePage.rows.first().getByRole('link').first();
+            await firstRowLink.click();
+            await expect(page).toHaveURL(/\/certificates\/detail\//);
+
+            // Delete from detail (trash icon → confirm)
+            await certPage.deleteFromDetail();
+
+            await expect(tablePage.rows).toHaveCount(2, { timeout: 10000 });
+        });
+
+        await test.step('Batch delete remaining 2 certs → verify all gone', async () => {
+            await tablePage.bulkDelete('Certificates');
+            // After delete, no rows should contain our CN prefix
+            const ourRows = tablePage.rows.filter({ hasText: cnPrefix });
+            await expect(ourRows).toHaveCount(0, { timeout: 10000 });
+        });
+    });
+});
+

--- a/czertainly-e2e/utils/certificateUtils.ts
+++ b/czertainly-e2e/utils/certificateUtils.ts
@@ -25,25 +25,157 @@ export interface RevokeCertificateOptions {
     reason?: string;        // X.509 CRL reason; defaults to "unspecified"
 }
 
+/**
+ * CSR (Certificate Signing Request)  - a request to CA to issue a digital certificate
+ * we provide our public key -> CA checks our identity and sign -> we get a real certificate
+ * keypair - it's our digital signiture:
+ *  private key - a secret one that only we have, we sign things using it, proving that they are from us
+ *  public key - we show to everyone, others use it to check our signiture
+ */
+
 export function generateCsr(commonName: string): { csr: string; privateKey: string } {
     logger.info(`Generating CSR for CN=${commonName}`);
 
     // 1. RSA-2048 keypair (industry-standard for TLS)
-    const keys = forge.pki.rsa.generateKeyPair(2048);
+    const keys = forge.pki.rsa.generateKeyPair(2048); // a library to work with RSA (one of the most popular crypto algorithm)
 
     // 2. Build CSR object
-    const csr = forge.pki.createCertificationRequest();
-    csr.publicKey = keys.publicKey;
-    csr.setSubject([{ name: 'commonName', value: commonName }]);
+    const csr = forge.pki.createCertificationRequest(); // create an empty CSR object
+    csr.publicKey = keys.publicKey; // attach our public key to the CSR object (future certificate will prove that key, e.g. CA proves that this owners has this public key )
+    // we don't share our private key
+    csr.setSubject([{ name: 'commonName', value: commonName }]); // to which name issue a digital certificate
+    // X.509 standard subject usually contains a few fields: Common Name (CN), Organization (O), Country (C) etc.
+    // we use only CN, CN = usually a domain (www.example.com) for TLS-certificates or a person name for personal-certs
+    // format = an array of objects {name, value}
 
     // 3. Sign the CSR with the private key using SHA-256
-    csr.sign(keys.privateKey, forge.md.sha256.create());
+    csr.sign(keys.privateKey, forge.md.sha256.create()); // by this signature CA can prove that this request was made by a real owner of the private key
+    // how this signature works mathematically:
+    //  1. we use SHA-256 hash algorithm for the content of the CSR
+    //  2. we encrypt that hash with the private key
+    //  3. others can decrypt it with the public key and compare the hashes - if they are equal -> the signature is valid
+    //  4. if someone changes the CSR after the signature -> the hash changes -> the signature won't match -> CA will see it
 
     // 4. Serialize to PEM (text format with -----BEGIN CERTIFICATE REQUEST----- headers)
+    // PEM - is a text format for crypto objects, Base64-coded content between the -----BEGIN CERTIFICATE REQUEST----- and -----END CERTIFICATE REQUEST----- lines.
+    // we return both parts:
+    //  1. CSR - to send to CA
+    //  2. private key - we store it for our later use, it is needed for real usage, e.g. TLS-server use it for handshake 
     return {
         csr: forge.pki.certificationRequestToPem(csr),
         privateKey: forge.pki.privateKeyToPem(keys.privateKey),
     };
+}
+
+/**
+ * self-signed certificate means it was not issued by CA but we issued it by ourselves
+ * it has all the formal fields (name, public key, validity, serial number, signature) but the signature is ours, not CA's -> basically noone would accept it as a true official certificate
+ * ILM should accept it as a valid structured but the issuer won't be trusted
+ */
+export function generateSelfSignedCert(
+    commonName: string,
+    validityDays: number = 365,
+): { pem: string; fingerprint: string } {
+    logger.info(`Generating self-signed cert for CN=${commonName}, valid ${validityDays} days`);
+
+    // 1. RSA-2048 keypair (same as for CSR)
+    const keys = forge.pki.rsa.generateKeyPair(2048);
+
+    // 2. Build certificate object
+    const cert = forge.pki.createCertificate(); // not createCertificationRequest() here, CSR is for a request, this one - is for a ready certificate
+    // a certificate has more fields: validity, issuer, serial, signature. CSR has only subject + public key + signature.
+    cert.publicKey = keys.publicKey;
+
+    // 3. Random 16-byte serial number (must be unique per cert)
+    cert.serialNumber = '01' + forge.util.bytesToHex(forge.random.getBytesSync(15));
+
+    // 4. Validity window: now → now + validityDays
+    const now = new Date();
+    cert.validity.notBefore = now;
+    cert.validity.notAfter = new Date(now.getTime() + validityDays * 24 * 60 * 60 * 1000);
+
+    // 5. Subject = Issuer (that's what "self-signed" means)
+    // here we have both subject and issuer
+    // Subject = to whom it was issued
+    // Issuer = who issued
+    // real certificate example: subject = CN=example.com, issuer = CN=Let's Encrypt R3
+    const attrs = [{ name: 'commonName', value: commonName }];
+    cert.setSubject(attrs);
+    cert.setIssuer(attrs);
+
+    // 6. Sign the cert with our own private key
+    // in real certificate it should be signed by the private key of CA
+    cert.sign(keys.privateKey, forge.md.sha256.create());
+
+    // 7. Compute SHA-256 fingerprint of DER-encoded cert
+    //  7.1 forge.pki.certificateToAsn1(cert) — here we convert cert object to ASN.1 (tree-structure, intermediate state), the cert inside is a tree structure, ASN.1 mirrors it
+    //  7.2 forge.asn1.toDer(...) — we serialize ASN.1 into DER (Distinguished Encoding Rules — binary format). PEM is de facto base64 wrapper around DER.
+    //      Fingerprint is counted from DER bytes, not from PEM text.
+    //  7.3 .getBytes() - we get these bytes as a string
+    //  7.4 forge.md.sha256.create() + md.update(bytes) — we create SHA-256 hasher using the DER bytes
+    //  7.5 md.digest().toHex() — we get the hash result as hex-string = the format of the API response when we upload a certificate
+    const derBytes = forge.asn1.toDer(forge.pki.certificateToAsn1(cert)).getBytes();
+    const md = forge.md.sha256.create();
+    md.update(derBytes);
+    const fingerprint = md.digest().toHex();
+
+    // 7. Return PEM + fingerprint
+    // here we return only pem and fingerprint, we don't save the private key since we aren't going to use it for TLS etc.
+    return {
+        pem: forge.pki.certificateToPem(cert),
+        fingerprint,
+    };
+}
+
+export async function uploadCertificate(
+    request: APIRequestContext,
+    pem: string,
+): Promise<{ fingerprint: string }> {
+    logger.info(`Uploading certificate to /api/v1/certificates/upload/async`);
+    const base64Pem = Buffer.from(pem).toString('base64'); //Node.js approach to convert a string to base64 
+    const response = await request.post('/api/v1/certificates/upload/async', {
+        data: {
+            certificate: base64Pem,
+            customAttributes: [],
+        },
+    });
+    if (!response.ok()) {
+        const errBody = await response.text();
+        throw new Error(`Failed to upload certificate: ${response.status()} - ${errBody}`);
+    }
+    return await response.json() as { fingerprint: string };
+}
+
+export async function findCertificateByFingerprint(
+    request: APIRequestContext,
+    fingerprint: string,
+): Promise<{ uuid: string } | null> {
+    logger.info(`Searching for certificate with fingerprint: ${fingerprint}`);
+    const response = await request.post('/api/v1/certificates', {
+        data: {
+            itemsPerPage: 10,
+            pageNumber: 1,
+            filters: [
+                {
+                    fieldSource: 'property',
+                    fieldIdentifier: 'FINGERPRINT',
+                    condition: 'EQUALS',
+                    value: fingerprint,
+                },
+            ],
+            includeArchived: false,
+        },
+    });
+    if (!response.ok()) {
+        const errBody = await response.text();
+        throw new Error(`Failed to search certificates: ${response.status()} - ${errBody}`);
+    }
+    const body = await response.json() as { certificates: Array<{ uuid: string }> };
+    if (body.certificates.length === 0) {
+        logger.info(`No certificate found with fingerprint: ${fingerprint}`);
+        return null;
+    }
+    return { uuid: body.certificates[0].uuid };
 }
 
 export async function waitForCertificateState(

--- a/czertainly-e2e/utils/env.ts
+++ b/czertainly-e2e/utils/env.ts
@@ -30,6 +30,7 @@ export type TestEnv = {
   authBaseUrl?: string;
   localAuthProviderName: string;
   smokePersist: boolean;  // SMOKE_PERSIST=true → reuse state between runs, skip teardown
+  kubeconfigPath?: string;  // KUBECONFIG_PATH — for local k8s access; ignored in-cluster (uses ServiceAccount token)
   smoke: SmokeEnv;
 };
 
@@ -50,6 +51,9 @@ export type SmokeEnv = {
   ejbcaCaName?: string;
   ejbcaEndEntityProfile?: string;
   ejbcaCertificateProfile?: string;
+
+  // SMK-005 - Issue Certificate through ACME
+  namespace?: string;  // SMOKE_TESTS_NAMESPACE — where the test creates Issuer / Certificate / Secret
 };
 
 function required(name: string): string {
@@ -77,6 +81,7 @@ export function loadEnv(): TestEnv {
     authBaseUrl: process.env.AUTH_BASE_URL, // Defaults to baseUrl/kc if not set
     localAuthProviderName: required('LOCAL_AUTH_PROVIDER_NAME'),
     smokePersist: process.env.SMOKE_PERSIST === 'true',
+    kubeconfigPath: process.env.KUBECONFIG_PATH,
     smoke: {
       discoveryProviderName: process.env.DISCOVERY_PROVIDER_NAME,
       discoveryProviderUrl: process.env.DISCOVERY_PROVIDER_URL,
@@ -92,6 +97,8 @@ export function loadEnv(): TestEnv {
       ejbcaCaName: process.env.EJBCA_CA_NAME,
       ejbcaEndEntityProfile: process.env.EJBCA_END_ENTITY_PROFILE,
       ejbcaCertificateProfile: process.env.EJBCA_CERTIFICATE_PROFILE,
+
+      namespace: process.env.SMOKE_TESTS_NAMESPACE,
     },
   };
 

--- a/czertainly-e2e/utils/k8sClient.ts
+++ b/czertainly-e2e/utils/k8sClient.ts
@@ -1,0 +1,75 @@
+/**
+ * k8sClient — centralized Kubernetes API access for test code.
+ *
+ * WHAT: k8s API client to do centralized authorization and exposes typed API clients (CoreV1Api, NetworkingV1Api, CustomObjectsApi, AuthorizationV1Api).
+ * 
+ * WHY: tests need to manage k8s resources (Issuer, Certificate, Secret) but shouldn't repeat auth setup.
+ * 
+ * HOW: 1. In-cluster first: testkube agent lives in-cluster and should have its own ServiceAccount aka service user with permissions.
+ *          loadFromCluster() reads the ServiceAccount token that k8s mounts into every pod at
+ *      /var/run/secrets/kubernetes.io/serviceaccount/token.
+ *      Works when the test runs inside the Testkube pod.
+ *      2. Fallback: loadFromFile(process.env.KUBECONFIG_PATH) - for local dev with a kubeconfig file.
+ *      3. If neither works — throw an error e.g. no k8s auth available: neither in-cluster service account token nor KUBECONFIG_PATH set.
+ *      4. Expose typed k8s API clients — CoreV1Api, NetworkingV1Api, CustomObjectsApi, AuthorizationV1Api as getter functions so callers don't reload auth per request.
+ */
+
+/**
+ *  CoreV1Api — namespaces, pods, secrets, services
+ *  NetworkingV1Api — Ingress
+ *  CustomObjectsApi — cert-manager CRD(Issuer, Certificate)
+ *  AuthorizationV1Api — check for permissions (SelfSubjectAccessReview)
+ */
+import { KubeConfig, CoreV1Api, NetworkingV1Api, CustomObjectsApi, AuthorizationV1Api } from '@kubernetes/client-node';
+import { Logger } from './Logger';
+
+const logger = new Logger('K8sClient');
+
+let kc: KubeConfig | undefined;
+
+export function getKubeConfig(): KubeConfig {
+    // checking cache (early return) - lazy initialization
+    if (kc) return kc;
+
+    const newKc = new KubeConfig();
+    if (process.env.KUBERNETES_SERVICE_HOST) {
+        try {
+            newKc.loadFromCluster();
+            logger.info('Loaded k8s config from in-cluster ServiceAccount');
+            kc = newKc;
+            return kc;
+        } catch (e) {
+            logger.debug(`loadFromCluster failed: ${e}. Trying KUBECONFIG_PATH fallback.`);
+        }
+    } else {
+        logger.debug('Not running in-cluster (KUBERNETES_SERVICE_HOST not set), trying KUBECONFIG_PATH fallback.');
+    }
+
+    const path = process.env.KUBECONFIG_PATH;
+    if (path) {
+        newKc.loadFromFile(path);
+        logger.info(`Loaded k8s config from file: ${path}`);
+        kc = newKc;
+        return kc;
+    }
+    throw new Error(
+        'No k8s auth available: neither in-cluster ServiceAccount token nor KUBECONFIG_PATH found. ' +
+        'Run inside a Testkube pod or set KUBECONFIG_PATH in .env.'
+    );
+}
+
+export function getCoreApi(): CoreV1Api {
+    return getKubeConfig().makeApiClient(CoreV1Api);
+}
+
+export function getNetworkingApi(): NetworkingV1Api {
+    return getKubeConfig().makeApiClient(NetworkingV1Api);
+}
+
+export function getCustomObjectsApi(): CustomObjectsApi {
+    return getKubeConfig().makeApiClient(CustomObjectsApi);
+}
+
+export function getAuthorizationApi(): AuthorizationV1Api {
+    return getKubeConfig().makeApiClient(AuthorizationV1Api);
+}


### PR DESCRIPTION
## Summary

- **SMK-007 — new smoke test:** upload certificate (via UI + API) and verify both single delete (via detail page) and batch delete (via list). Self-signed test certs generated in-test via node-forge, hermetic cleanup via API in \`afterEach\`.
- **SMK-005 — reconnaissance test (skipped for now):** initial scaffolding for ACME smoke — \`k8sClient.ts\`, \`SelfSubjectAccessReview\`-based permission recon. Skipped via \`test.skip\` because our Testkube ServiceAccount doesn't yet have RBAC to create Issuer/Certificate resources in the cluster. Blocked on cluster-admin availability to apply the RBAC manifest documented in QA notes.

## What's added / changed

**New utilities in \`certificateUtils.ts\`:**
- \`generateSelfSignedCert\` — node-forge based, returns PEM + fingerprint
- \`uploadCertificate\` — API upload via \`POST /api/v1/certificates/upload/async\`
- \`findCertificateByFingerprint\` — bridges known fingerprint → UUID for cleanup

**\`CertificatePage\` extensions:**
- Upload flow: \`uploadButton\` locator, \`openUploadModal()\`, \`pasteCertificatePem()\`, \`submitUpload()\`
- Delete-from-detail flow: \`deleteButton\`, delete confirm dialog locators, \`deleteFromDetail()\`

**\`k8sClient.ts\` (new, part of SMK-005):**
- Centralized KubeConfig loader — in-cluster first (with \`KUBERNETES_SERVICE_HOST\` presence check), fallback to \`KUBECONFIG_PATH\` file, throws with clear message otherwise
- Getter functions for CoreV1Api, NetworkingV1Api, CustomObjectsApi, AuthorizationV1Api

**\`env.ts\`:**
- New optional \`kubeconfigPath\` (top-level, for local k8s access) and \`smoke.namespace\` (\`SMOKE_TESTS_NAMESPACE\`, for SMK-005 target namespace)

## Test plan

- [x] SMK-007 passes locally (12.5s)
- [x] Full suite passes with SMK-005 skipped — 1 skipped, 5 passed (~42s)
- [x] afterEach cleanup verified — all fingerprints return null (already deleted in test), no orphans
- [ ] SMK-005: to be re-enabled once RBAC is granted for the Testkube ServiceAccount in \`testkube-runner\` namespace